### PR TITLE
Fixing renewal of expired access token

### DIFF
--- a/connections/github.py
+++ b/connections/github.py
@@ -8,7 +8,7 @@ _token = None
 _gh = None
 
 def get_token():
-    global token
+    global _token
     app_id = config.get_section('github').get('app_id')
     installation_id = config.get_section('github').get('installation_id')
     private_key_path = config.get_section('github').get('private_key')
@@ -19,9 +19,9 @@ def get_token():
 
     github_integration = GithubIntegration(app_id, private_key)
     # Note that installation access tokens last only for 1 hour, you will need to regenerate them after they expire.
-    token = github_integration.get_access_token(installation_id)
+    _token = github_integration.get_access_token(installation_id)
 
-    return token
+    return _token
 
 
 def connect():
@@ -30,6 +30,6 @@ def connect():
 
 def get_instance():
     global _gh, _token
-    if not _gh or (_token and datetime.datetime.utcnow() > token.expires_at):
+    if not _gh or (_token and datetime.datetime.utcnow() > _token.expires_at):
         _gh = connect()
     return _gh


### PR DESCRIPTION
Code was prepared to renew the token which expires normally after an hour. There was a slight mismatch in naming the variable holding the token: `token` vs `_token`.

This PR address one scenario of #20 (the issue should be kept open because there may be other scenarios in which the bot should tolerate communication failures).