### PR TITLE
Add port as option

### DIFF
--- a/eessi_bot_software_layer.py
+++ b/eessi_bot_software_layer.py
@@ -97,7 +97,7 @@ def main():
         # Run as web app
         app = create_app(klass=EESSIBotSoftwareLayer)
         log("EESSI bot for software layer started!")
-        waitress.serve(app, listen='*:%s'%(opts.port))
+        waitress.serve(app, listen='*:%s' % opts.port)
 
 if __name__ == '__main__':
     main()

--- a/eessi_bot_software_layer.py
+++ b/eessi_bot_software_layer.py
@@ -97,7 +97,7 @@ def main():
         # Run as web app
         app = create_app(klass=EESSIBotSoftwareLayer)
         log("EESSI bot for software layer started!")
-        waitress.serve(app, listen='*:3000')
+        waitress.serve(app, listen='*:%s'%(opts.port))
 
 if __name__ == '__main__':
     main()

--- a/tools/args.py
+++ b/tools/args.py
@@ -23,4 +23,9 @@ def parse():
         "-f", "--file",
         help="use event data from a JSON file",
     )
+
+    parser.add_argument(
+        "-p", "--port", default=3000,
+        help="listen on a specific port for events (default 3000)",
+    )
     return parser.parse_args()


### PR DESCRIPTION
Small update to let one specify a port number on which the bot listens for connections/events. Smee client also has to use that port.

Specifying the port number can be necessary if several bots or bot instances run on the same node.