### PR TITLE
Check build job status and comment on PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.py[cod]
+*.log
+app.cfg
+events_log/

--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ pwd
 git fetch origin pull/24/head:PR24
 git checkout PR24
 ```
-Note the output of `pwd`. This will be used to replace `PATH_TO_EESSI_BOT` in the configuration file `app.cfg` (see [Step 5.4](#step5.4)).
 
 The EESSI bot requires some Python packages to be installed. It is recommended to install these in a virtual environment based on Python 3.7 or newer. See the below sequence for an example on how to set up the environment, to activate it and to install the requirements for the EESSI bot. The sequence assumes that you are in the directory containing the bot's script:
 ```

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ At the [app settings page](https://github.com/settings/apps) click "New GitHub A
 - GitHub App name: give the app a name of you choice
 - Homepage URL: use the Smee.io channel (https://smee.io/CHANNEL-ID) created in [Step 1](#step1)
 - Webhook URL: use the Smee.io channel (https://smee.io/CHANNEL-ID) created in [Step 1](#step1)
-- Webhook secret: create a secret token which is used to verify the webhook sender
+- Webhook secret: create a secret token which is used to verify the webhook sender. For example:
+  ```shell
+  python3 -c 'import secrets; print(secrets.token_hex(64))'
+  ```
 - Permissions: assign permissions to the app it needs (e.g., read access to commits, issues, pull requests); those can be changed later on; some permissions (e.g., metadata) will be selected automatically because of others you have chosen
 - Events: subscribe the app to events it shall react on (e.g., related to pull requests)
 - Select that the app can only be installed by this (your) GitHub account
@@ -173,7 +176,7 @@ Then try to install the requirements with
 pip3 install --user -r requirements.txt
 ```
 
-Alternatively, you may try to install some of the dependencies by fixing their version. For example, on the CitC cluster (https://github.com/EESSI/hackathons/tree/main/2021-12/citc) installing PyGithub failed due to some problem installing its dependency PyNaCl. Apparently, PyGithub only required version 1.4.0 of PyNaCl but the most recent version 1.5.0 failed to install. Hence, when installing PyNaCl version 1.4.0 first, then PyGithub could be installed. Example commands
+Alternatively, you may try to install some of the dependencies by fixing their version. For example, on the [EESSI CitC cluster](https://github.com/EESSI/hackathons/tree/main/2021-12/citc) installing PyGithub failed due to some problem installing its dependency PyNaCl. Apparently, PyGithub only required version 1.4.0 of PyNaCl but the most recent version 1.5.0 failed to install. Hence, when installing PyNaCl version 1.4.0 first, then PyGithub could be installed. Example commands
 
 ```
 pip3 install --user PyNaCl==1.4.0
@@ -228,17 +231,17 @@ The example file (`app.cfg.example`) includes notes on what you have to adjust t
 ### Section `[github]`
 The section `[github]` contains information for connecting to GitHub:
 ```
-app_id = 199740
+app_id = 123456
 ```
-Replace '199740' with the id of your GitHub App. You find the id of your GitHub App via the page [GitHub Apps](https://github.com/settings/apps). On this page, select the app you have registered in [Step 2](#step2). On the opened page you will find the `app_id` in the section headed "About" listed as 'App ID'.
+Replace '123456' with the id of your GitHub App. You find the id of your GitHub App via the page [GitHub Apps](https://github.com/settings/apps). On this page, select the app you have registered in [Step 2](#step2). On the opened page you will find the `app_id` in the section headed "About" listed as 'App ID'.
 ```
 app_name = 'MY-bot'
 ```
 Is a short name representing your bot. It will appear in comments to a pull request. For example, it could include the name of the cluster where the bot runs and a label representing the user that runs the bot: `CitC-TR`. *NOTE avoid putting an actual username here as it will be visible on potentially publicly accessible GitHub pages.*
 ```
-installation_id = 25669742
+installation_id = 12345678
 ```
-Replace '256669742' with the id of the installation of your GitHub App (installed in [Step 3](#step3)). You find the id of your GitHub App via the page [GitHub Apps](https://github.com/settings/apps). On this page, select the app you have registered in [Step 2](#step2). For determining the `installation_id` select "Install App" in the menu on the left-hand side. Then click on the gearwheel button of the installation (to the right of the "Installed" label). The URL of the resulting page contains the `installation_id` -- the number after the last "/". The `installation_id` is also provided in the payload of every event within the top-level record named "installation". You can see the events and their payload on the webpage of your Smee.io channel (https://smee.io/CHANNEL-ID). Alternatively, you can see the events in the "Advanced" section of your GitHub App: Open the page [GitHub Apps](https://github.com/settings/apps), then select the app you have registered in [Step 2](#step2), and choose "Advanced" in the menu on the left-hand side.
+Replace '12345678' with the id of the installation of your GitHub App (installed in [Step 3](#step3)). You find the id of your GitHub App via the page [GitHub Apps](https://github.com/settings/apps). On this page, select the app you have registered in [Step 2](#step2). For determining the `installation_id` select "Install App" in the menu on the left-hand side. Then click on the gearwheel button of the installation (to the right of the "Installed" label). The URL of the resulting page contains the `installation_id` -- the number after the last "/". The `installation_id` is also provided in the payload of every event within the top-level record named "installation". You can see the events and their payload on the webpage of your Smee.io channel (https://smee.io/CHANNEL-ID). Alternatively, you can see the events in the "Advanced" section of your GitHub App: Open the page [GitHub Apps](https://github.com/settings/apps), then select the app you have registered in [Step 2](#step2), and choose "Advanced" in the menu on the left-hand side.
 ```
 private_key = PATH_TO_PRIVATE_KEY
 ```
@@ -327,7 +330,7 @@ This is the full path to the Slurm command used for manipulating existing jobs. 
 The bot consists of three components, the Smee client, the event handler and the job manager. Running the Smee client was explained in [Step 1](#step1).
 
 ## <a name="step6.1"></a>Step 6.1: Running the event handler
-As the event handler may run for a long time, it is adviced to run it in a `screen` or `tmux` session.
+As the event handler may run for a long time, it is advised to run it in a `screen` or `tmux` session.
 
 The event handler is provided by the Python script `eessi_bot_software_layer.py`.
 Change directory to `eessi-bot-software-layer` (which was created by cloning the
@@ -347,7 +350,7 @@ The event handler writes log information to the file `pyghee.log`.
 Note, if you run the bot on a frontend of a cluster with multiple frontends make sure that both the Smee client and the event handler run on the same machine.
 
 ## <a name="step6.2"></a>Step 6.2: Running the job manager
-As the job manager may run for a long time, it is adviced to run it in a `screen` or `tmux` session.
+As the job manager may run for a long time, it is advised to run it in a `screen` or `tmux` session.
 
 The job manager is provided by the Python script `eessi_bot_job_manager_layer.py`. You can run the job manager from the directory `eessi-bot-software-layer` simply by
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ build_job_script = PATH_TO_EESSI_BOT/scripts/eessi-bot-build.slurm
 This points to the job script which will be submitted by the event handler.
 ```
 cvmfs_customizations = { "/etc/cvmfs/default.local": "CVMFS_HTTP_PROXY=\"http://PROXY_DNS_NAME:3128|http://PROXY_IP_ADDRESS:3128\"" }
+```
 It may happen that we need to customize the CVMFS configuration for the build
 job. The value of cvmfs_customizations is a dictionary which maps a file name
 to an entry that needs to be appended to that file. In the example line above, the

--- a/README.md
+++ b/README.md
@@ -275,6 +275,13 @@ jobs_base_dir = $HOME/jobs
 ```
 Replace `$HOME/jobs` with a path under which information about jobs will be stored. Per job the directory structure under `jobs_base_dir` is `YYYY.MM/pr_PR_NUMBER/event_EVENT_ID/run_RUN_NUMBER/OS+SUBDIR`. The base directory will contain symlinks using the job ids pointing to the job's working directory `YYYY.MM/...`.
 ```
+load_modules = MODULE1/VERSION1,MODULE2/VERSION2,...
+```
+This setting provides a means to load modules in the `build_job_script`.
+None to several modules can be provided in a comma-separated list. It is
+read by the bot and handed over to `build_job_script` via the parameter
+`--load-modules`.
+```
 local_tmp = /tmp/$USER/EESSI
 ```
 This is the path to a temporary directory on the node building the stack, i.e., on a compute/worker node. You may have to change this if temporary storage under '/tmp' does not exist or is too small. This setting will be used for the environment variable `EESSI_TMPDIR`. Variables in the value may be esaped with '\' to delay their expansion to the start of the build_job_script. This can be used for referencing environment variables that are only set inside a Slurm job.

--- a/README.md
+++ b/README.md
@@ -150,10 +150,19 @@ git checkout PR24
 ```
 Note the output of `pwd`. This will be used to replace `PATH_TO_EESSI_BOT` in the configuration file `app.cfg` (see [Step 5.4](#step5.4)).
 
-The EESSI bot requires some Python packages to be installed. See the top of this page, or simply run (the `requirements.txt` file is provided by the EESSI bot repository)
+The EESSI bot requires some Python packages to be installed. It is recommended to install these in a virtual environment based on Python 3.7 or newer. See the below sequence for an example on how to set up the environment, to activate it and to install the requirements for the EESSI bot. The sequence assumes that you are in the directory containing the bot's script:
 ```
-pip3 install --user -r requirements.txt
+cd ..
+python3.7 -m venv venv_bot_p37
+source venv_bot_p37/bin/activate
+python --version                     # output should match 'Python 3.7.*$'
+which python                         # output should match '*/venv_bot_p37/bin/python$'
+python -m pip install --upgrade pip
+cd eessi-bot-software-layer
+pip install -r requirements.txt
 ```
+
+Note, before you can start the bot components (see below), you have to activate the virtual environment with `source venv_bot_p37/bin/activate`. You can deactivate it simply by running `deactivate`.
 
 **Troubles installing some of the requirements or their dependencies?**
 You may try to upgrade `pip` first with

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mkdir smee
 cd smee
 singularity pull docker://node
 singularity exec node_latest.sif npm install smee-client
-cat << EOF > smee
+cat << 'EOF' > smee
 #!/usr/bin/env bash
 
 BASEDIR=$(dirname "$0")
@@ -160,7 +160,7 @@ As of today, [PR#3 of PyGHee](https://github.com/boegel/PyGHee/pull/3) is not be
 cd SOME_PATH
 git clone https://github.com/boegel/PyGHee.git
 cd PyGHee
-git fetch origin pull/3/main:PR3
+git fetch origin pull/3/head:PR3
 git checkout PR3
 ```
 and set PYTHONPATH as described above before you run the event handler. The job manager might use the version installed with `pip`. The only change of PR#3 is the added function `read_event_from_json`. However, for better reproducibility it could be useful to run both components with the same version of PyGHee.

--- a/README.md
+++ b/README.md
@@ -182,22 +182,11 @@ pip3 install --user -r requirements.txt
 
 ### <a name="step4.1"></a>Step 4.1 Using a development version/branch of PyGHee
 
-The above command `pip3 install --user -r requirements.txt` installs the latest release of the PyGHee library. If you want to use a development version/branch, i.e., what is available from GitHub or your own local copy, you have to set `PYTHONPATH` correctly. Assuming the library's main directory is `SOME_PATH/PyGHee` do the following in the terminal/shell/script where you run the bot:
+The above command `pip3 install --user -r requirements.txt` installs the latest release of the PyGHee library. If you want to use a development version/branch, i.e., what is available from GitHub or your own local copy, you have to set `$PYTHONPATH` correctly. Assuming the library's main directory is `SOME_PATH/PyGHee` do the following in the terminal/shell/script where you run the bot:
   
 ```
-export PYTHONPATH=SOME_PATH/PyGHee
+export PYTHONPATH=SOME_PATH/PyGHee:$PYTHONPATH
 ```
-
-As of today, [PR#3 of PyGHee](https://github.com/boegel/PyGHee/pull/3) is not being merged yet. Hence, you need to do the following to use it for running the EESSI bot.
-
-```
-cd SOME_PATH
-git clone https://github.com/boegel/PyGHee.git
-cd PyGHee
-git fetch origin pull/3/head:PR3
-git checkout PR3
-```
-and set PYTHONPATH as described above before you run the event handler. The job manager might use the version installed with `pip`. The only change of PR#3 is the added function `read_event_from_json`. However, for better reproducibility it could be useful to run both components with the same version of PyGHee.
 
 ## <a name="step5"></a>Step 5: Configuring the EESSI bot on the `bot machine`
 

--- a/README.md
+++ b/README.md
@@ -19,21 +19,27 @@ Requires:
 pip3 install --user -r requirements.txt
 ```
 
-# Detailed instructions to set up development environment
+# Instructions to set up the EESSI bot components
 
-The following sections describe and illustrate the steps necessary to set up the development environment for the EESSI bot.
+The following sections describe and illustrate the steps necessary
+to set up the EESSI bot for the software layer. The bot consists of
+two main components provided in this repository:
 
-## Prerequisites
+- An event handler `eessi_bot_software_layer.py` which receives events from a GitHub repository and acts on them.
+- A job manager `eessi_bot_job_manager.py` which monitors a Slurm job queue and acts on state changes of jobs submitted by the event handler.
 
-- GitHub account
-- GitHub repository on whose events the bot shall react to
-- Linux machine where the EESSI bot shall run (some steps may require sudo access)
+## <a name="prerequisites"></a>Prerequisites
 
-## Step 1: Smee.io channel and smee client
+- GitHub account(s) (two needed for a development scenario), referring to them as `YOU_1` and `YOU_2` below
+- A fork, say `YOU_1/software-layer`, of [EESSI/software-layer](https://github.com/EESSI/software-layer) and a fork, say `YOU_2/software-layer` of your first fork if you want to emulate the bot's behaviour but not change EESSI's repository. The EESSI bot will act on events triggered for the first fork (`YOU_1/software-layer`).
+- Access to a frontend/login node/service node of a Slurm cluster where the EESSI bot components shall run. For the sake of brevity, we call this node simply `bot machine`.
+- The EESSI bot components and the (build) jobs will frequently access the Internet. Hence, worker nodes and `bot machine` of the Slurm cluster need access to the Internet.
 
-We use smee.io as a service to relay events from GitHub to the EESSI bot. To do so, create a new channel on the page https://smee.io and note the URL, e.g., https://smee.io/CHANNEL_ID
+## <a name="step1"></a>Step 1: Smee.io channel and smee client
 
-On the Linux machine which runs the EESSI bot we need a tool which receives events relayed from https://smee.io/CHANNEL_ID and forwards it to the EESSI bot. We use the Smee client for this. The Smee client can be installed globally with
+We use smee.io as a service to relay events from GitHub to the EESSI bot. To do so, create a new channel on the page https://smee.io and note the URL, e.g., https://smee.io/CHANNEL-ID
+
+On the `bot machine` we need a tool which receives events relayed from https://smee.io/CHANNEL-ID and forwards it to the EESSI bot. We use the Smee client for this. The Smee client can be installed globally with
 
 ```
 npm install -g smee-client
@@ -67,24 +73,39 @@ export PATH=$PATH:$PWD
 Finally, run the Smee client as follows
 
 ```
-smee --url https://smee.io/CHANNEL_ID
+smee --url https://smee.io/CHANNEL-ID
+```
+
+If the event handler (see [Step 6.1](#step6.1)) receives events on a port different than the default (3000), you need to specify the port via the parameter `--port PORTNUMBER`, for example,
+
+```
+smee --url https://smee.io/CHANNEL-ID --port 3030
 ```
 
 Alternatively, you may use a container providing the smee client. For example,
 
 ```
 singularity pull docker://deltaprojects/smee-client
-singularity run smee-client_latest.sif --url https://smee.io/CHANNEL_ID
+singularity run smee-client_latest.sif --url https://smee.io/CHANNEL-ID
 ```
+
+or
+
+```
+singularity pull docker://deltaprojects/smee-client
+singularity run smee-client_latest.sif --url https://smee.io/CHANNEL-ID --port 3030
+```
+
+for specifying a different port than the default (3000).
 
 ## <a name="step2"></a>Step 2: Registering GitHub App
 
-We first need to register a GitHub App, link it to the Smee.io channel, set a secret token to verify the webhook sender, set some permissions for the app, subscribe it to selected events and define that this app should only be installed in your account.
+We need to register a GitHub App, link it to the Smee.io channel, set a secret token to verify the webhook sender, set some permissions for the app, subscribe it to selected events and define that this app should only be installed in your account.
 
 At the [app settings page](https://github.com/settings/apps) click "New GitHub App" and fill in the page, particular the following fields
 - GitHub App name: give the app a name of you choice
-- Homepage URL: use the Smee.io channel (https://smee.io/CHANNEL_ID) created in Step 1
-- Webhook URL: use the Smee.io channel (https://smee.io/CHANNEL_ID) created in Step 1
+- Homepage URL: use the Smee.io channel (https://smee.io/CHANNEL-ID) created in [Step 1](#step1)
+- Webhook URL: use the Smee.io channel (https://smee.io/CHANNEL-ID) created in [Step 1](#step1)
 - Webhook secret: create a secret token which is used to verify the webhook sender
 - Permissions: assign permissions to the app it needs (e.g., read access to commits, issues, pull requests); those can be changed later on; some permissions (e.g., metadata) will be selected automatically because of others you have chosen
 - Events: subscribe the app to events it shall react on (e.g., related to pull requests)
@@ -92,23 +113,25 @@ At the [app settings page](https://github.com/settings/apps) click "New GitHub A
 
 Click on "Create GitHub App"
 
-## Step 3: Installing GitHub App (might trigger first event to EESSI bot)
+## <a name="step3"></a>Step 3: Installing GitHub App
+
+_Note, this will trigger the first event (`installation`). While the EESSI bot is not running yet, you can inspect this via the webpage for your Smee channel. Just open https://smee.io/CHANNEL-ID in a browser and browse through the information included in the event. Naturally, some of the information will be different for other types of events._
 
 You need to install the GitHub App -- essentially telling GitHub to link the app to an account and one, several or all repositories on whose events the app then should act upon.
+  
+Go to the page https://github.com/settings/apps and select the app you want to install by clicking on the icon left to the app's name or on the "Edit" button right to the name of the app. On the next page you should see the menu item "Install App" on the left-hand side. When you click on this you should see a page with a list of accounts you can install the app on. Choose one and click on the "Install" button next to it. This leads to a page where you can select the repositories on whose the app should react to. Here, for the sake of simplicity, choose just `YOU_1/software-layer` as described in [Prerequisites](#prerequisites). Select one, multiple or all and click on the "Install" button.
 
-Go to the page https://github.com/settings/apps and select the app you want to install by clicking on the icon left to the apps name or on the "Edit" button right to the name of the app. On the next page you should see the menu item "Install App" on the left-hand side. When you click on this you should see a page with a list of accounts you can install the app on. Choose one and click on the "Install" button next to it. This leads to a page where you can select the repositories on whose the app should react to. Select one, multiple or all and click on the "Install" button.
-
-## Step 4: Installing the EESSI bot on Linux machine
+## <a name="step4"></a>Step 4: Installing the EESSI bot on a `bot machine`
 
 The EESSI bot for the software layer is available from https://github.com/EESSI/eessi-bot-software-layer
 
-Get the EESSI bot onto the Linux machine by running something like
+Get the EESSI bot _installed_ onto the `bot machine` by running something like
 
 ```
 git clone https://github.com/EESSI/eessi-bot-software-layer.git
 ```
 
-If you want to develop the EESSI bot, it is recommended that you fork the repository and use the fork on the Linux machine.
+If you want to develop the EESSI bot, it is recommended that you fork the repository and use the fork on the `bot machine`.
 
 The EESSI bot requires some Python packages to be installed. See the top of this page, or simply run (the `requirements.txt` file is provided by the EESSI bot repository)
 ```
@@ -123,43 +146,53 @@ pip3 install --user PyNaCl==1.4.0
 pip3 install --user -r requirements.txt
 ```
 
-### Step 4.1 Using the development version of PyGHee
+### <a name="step4.1"></a>Step 4.1 Using a development version/branch of PyGHee
 
-The above command `pip3 install --user -r requirements.txt` installs the latest release of the PyGHee library. If you want to use the development version, i.e., what is available from GitHub or your own local copy, you have to set `PYTHONPATH` correctly. Assume the library's main directory is `SOME_PATH/PyGHee` then do the following in the terminal/shell/script where you run the bot:
-
+The above command `pip3 install --user -r requirements.txt` installs the latest release of the PyGHee library. If you want to use a development version/branch, i.e., what is available from GitHub or your own local copy, you have to set `PYTHONPATH` correctly. Assuming the library's main directory is `SOME_PATH/PyGHee` do the following in the terminal/shell/script where you run the bot:
+  
 ```
 export PYTHONPATH=SOME_PATH/PyGHee
 ```
 
-## Step 5: Configuring and running EESSI bot on Linux machine
+As of today, [PR#3 of PyGHee](https://github.com/boegel/PyGHee/pull/3) is not being merged yet. Hence, you need to do the following to use it for running the EESSI bot.
 
-You need to set up two environment variables: `GITHUB_TOKEN` and `GITHUB_APP_SECRET_TOKEN`.
+```
+cd SOME_PATH
+git clone https://github.com/boegel/PyGHee.git
+cd PyGHee
+git fetch origin pull/3/main:PR3
+git checkout PR3
+```
+and set PYTHONPATH as described above before you run the event handler. The job manager might use the version installed with `pip`. The only change of PR#3 is the added function `read_event_from_json`. However, for better reproducibility it could be useful to run both components with the same version of PyGHee.
 
-### Step 5.1: GitHub Personal Access Token (PAT)
+## <a name="step5"></a>Step 5: Configuring the EESSI bot on the `bot machine`
 
+For the event handler, you need to set up two environment variables: `GITHUB_TOKEN` ([Step 5.1](#step5.1)) and `GITHUB_APP_SECRET_TOKEN` ([Step 5.2](#step5.2)). For both the event handler and the job manager you need a private key ([Step 5.3](#step5.3)).
+
+### <a name="step5.1"></a>Step 5.1: GitHub Personal Access Token (PAT)
 Create a Personal Access Token (PAT) for your GitHub account via the page https://github.com/settings/tokens where you find a button "Generate new token".
 Give it meaningful name (field titled "Note") and set the expiration date. Then select the scopes this PAT will be used for. Then click "Generate token". On the result page, take note/copy the resulting token string -- it will only be shown once.
 
-On the Linux machine set the environment variable `GITHUB_TOKEN`, e.g.
+On the `bot machine` set the environment variable `GITHUB_TOKEN`, e.g.
 ```
 export GITHUB_TOKEN='THE_TOKEN_STRING'
 ```
 
-### Step 5.2: GitHub App Secret Token
-The GitHub App Secret Token is used to verify the webhook sender. You should have created one already when registering a new GitHub App in Step 1.
+### <a name="step5.2"></a>Step 5.2: GitHub App Secret Token
+The GitHub App Secret Token is used to verify the webhook sender. You should have created one already when registering a new GitHub App in [Step 2](#step2).
 
-On the Linux machine set the environment variable `GITHUB_APP_SECTRET_TOKEN`, e.g.
+On the `bot machine` set the environment variable `GITHUB_APP_SECTRET_TOKEN`, e.g.
 ```
 export GITHUB_APP_SECRET_TOKEN='THE_SECRET_TOKEN_STRING'
 ```
 Note, depending on the characters used in the string you will likely have to use single quotes when setting the value of the environment variable.
 
-### Step 5.3: Create a private key and store it on the Linux machine
-The private key is needed to let the app authenticate when updating information at the repository such as commenting on PRs, adding labels, etc. You can create the key at the page of the GitHub App you have registered in Step 1.
+### <a name="step5.3"></a>Step 5.3: Create a private key and store it on the `bot machine`
+The private key is needed to let the app authenticate when updating information at the repository such as commenting on PRs, adding labels, etc. You can create the key at the page of the GitHub App you have registered in [Step 2](#step2).
 
-Open the page https://github.com/settings/apps and then click on the icon left to the name of the GitHub App for the EESSI bot or the "Edit" button for the app. Near the end of the page you will find a section "Private keys" where you can create a private key by clicking on the button "Generate a private key". The private key should be automatically downloaded to your local computer. Copy it to the Linux machine and note the full path to it.
+Open the page https://github.com/settings/apps and then click on the icon left to the name of the GitHub App for the EESSI bot or the "Edit" button for the app. Near the end of the page you will find a section "Private keys" where you can create a private key by clicking on the button "Generate a private key". The private key should be automatically downloaded to your local computer. Copy it to the `bot machine` and note the full path to it (`PATH_TO_PRIVATE_KEY`).
 
-### Step 5.4: Obtain bot repository
+### <a name="step5.4"></a>Step 5.4: Obtain EESSI bot repository
 
 The bot needs a few scripts. These and an example configuration file are provided by the repository [EESSI/eessi-bot-software-layer](https://github.com/EESSI/eessi-bot-software-layer) (or your fork of it).
 
@@ -169,38 +202,195 @@ First, clone the EESSI/eessi-bot-software-layer repository (or your fork of it) 
 git clone https://github.com/EESSI/eessi-bot-software-layer.git
 ```
 
-### Step 5.5: Create the configuration file `app.cfg`
+After cloning the bot's repository, change directory with `cd eessi-bot-software-layer` and note the full path of the directory (`PATH_TO_EESSI_BOT`).
 
-After cloning the bot's repository, change directory with `cd eessi-bot-software-layer` and note the full path of the directory (`pwd`).
+### <a name="step5.5"></a>Step 5.5: Create the configuration file `app.cfg`
 
-If there is no `app.cfg` in the directory, create an initial version from `app.cfg.example`.
+If there is no `app.cfg` in the directory `PATH_TO_EESSI_BOT` yet, create an initial version from `app.cfg.example`.
 
 ```
 cp -i app.cfg.example app.cfg
 ```
 
-Now set some values as follows:
+The example file (`app.cfg.example`) includes notes on what you have to adjust to run the bot in your environment.
 
+### Section `[github]`
+The section `[github]` contains information for connecting to GitHub:
 ```
-private_key = FULL_PATH_TO_PRIVATE_KEY
-build_job_script = PATH_TO_BOT_REPO/scripts/eessi-bot-build.slurm
+app_id = 199740
 ```
+Replace '199740' with the id of your GitHub App. You find the id of your GitHub App via the page [GitHub Apps](https://github.com/settings/apps). On this page, select the app you have registered in [Step 2](#step2). On the opened page you will find the `app_id` in the section headed "About" listed as 'App ID'.
+```
+app_name = 'MY-bot'
+```
+Is a short name representing your bot. It will be used for adding comments to a pull request. For example, it could include the name of the cluster where the bot runs and the username that runs the bot: `CitC-trz42`.
+```
+installation_id = 25669742
+```
+Replace '256669742' with the id of the installation of your GitHub App (installed in [Step 3](#step3)). You find the id of your GitHub App via the page [GitHub Apps](https://github.com/settings/apps). On this page, select the app you have registered in [Step 2](#step2). For determining the `installation_id` select "Install App" in the menu on the left-hand side. Then click on the gearwheel button of the installation (to the right of the "Installed" label). The URL of the resulting page contains the `installation_id` -- the number after the last "/". The `installation_id` is also provided in the payload of every event within the top-level record named "installation". You can see the events and their payload on the webpage of your Smee.io channel (https://smee.io/CHANNEL-ID). Alternatively, you can see the events in the "Advanced" section of your GitHub App: Open the page [GitHub Apps](https://github.com/settings/apps), then select the app you have registered in [Step 2](#step2), and choose "Advanced" in the menu on the left-hand side.
+```
+private_key = PATH_TO_PRIVATE_KEY
+```
+Replace `PATH_TO_PRIVATE_KEY` with the path you have noted in [Step 5.3](#step5.3).
 
-You will also need to set the `app_id` and the `installation_id`. You find the id of your GitHub App via the page [GitHub Apps](https://github.com/settings/apps). On this page, select the app you have registered in [Step 2](#step2). On page of the app you will find the `app_id` listed as 'App ID'. For the `installation_id` select 'Install App' in the menu on the left-hand side. Then click on the gearwheel button of the installation (to the right of the 'Installed' label). The URL of the resulting page contains the `installation_id` -- the number after the last '/'.
+### Section `[buildenv]`
+The section `[buildenv]` contains information about the build environment.
+```
+jobs_base_dir = $HOME/jobs
+```
+Replace `$HOME/jobs` with a path under which information about jobs will be stored. Per job the directory structure under `jobs_base_dir` is `YYYY.MM/pr_PR_NUMBER/event_EVENT_ID/run_RUN_NUMBER/OS+SUBDIR`. The base directory will contain symlinks using the job ids pointing to the job's working directory `YYYY.MM/...`.
+```
+local_tmp = /tmp/$USER/EESSI
+```
+This is the path to a temporary directory on the node building the stack, i.e., on a compute/worker node. You may have to change this if temporary storage under '/tmp' does not exist or is too small. This setting will be used for the environment variable `EESSI_TMPDIR`.
+```
+build_job_script = PATH_TO_EESSI_BOT/scripts/eessi-bot-build.slurm
+```
+This points to the job script which will be submitted by the event handler.
+```
+submit_command = /usr/bin/sbatch
+```
+This is the full path to the Slurm command used for submitting batch jobs. You may want to verify if `sbatch` is provided at that path or determine its actual location (`which sbatch`).
+```
+slurm_params = "--hold"
+```
+This defines additional parameters for submitting batch jobs. "--hold" should be kept or the bot might not work as intended (the release step would be circumvented). Additional parameters, for example, to specify an account, a partition or any other parameters supported by `sbatch`, may be added to customize the submission to your environment.
 
-Replace default values for `app_id` and `installation_id` in `app.cfg` with the values you have obtained as described above.
+### Section `[architecturetargets]`
+The section `[architecturetargets]` defines for which targets (OS/SUBDIR), e.g., `linux/amd/zen2` the EESSI bot should submit jobs and what additional `sbatch` parameters will be used for requesting a compute node with the CPU microarchitecture needed to build the software stack.
+```
+arch_target_map = { "linux/x86_64/generic" : "--constraint shape=c4.2xlarge", "linux/x86_64/amd/zen2" : "--constraint shape=c5a.2xlarge" }
+```
+The map has one to many entries of the format `OS/SUBDIR : ADDITIONAL_SBATCH_PARAMETERS`. For your cluster, you will have to figure out which microarchitectures (`SUBDIR`) are available (as `OS` only `linux` is currently supported) and how to instruct Slurm to request them (`ADDITIONAL_SBATCH_PARAMETERS`).
 
-### Step 5.6: Run the EESSI bot
+### Section `[job_manager]`
+The section `[job_manager]` contains information needed by the job manager.
+```
+job_ids_dir = $HOME/jobs/ids
+```
+Path to where the job manager stores information about jobs to be tracked. Under this directory it will store information about submitted/running jobs under `submitted` and about finished jobs under `finished`.
+```
+poll_command = /usr/bin/squeue
+```
+This is the full path to the Slurm command used for checking which jobs exist. You may want to verify if `squeue` is provided at that path or determine its actual location (`which squeue`).
+```
+poll_interval = 60
+```
+This defines how often the job manager checks the status of the jobs. The unit of the value is seconds.
+```
+scontrol_command = /usr/bin/scontrol
+```
+This is the full path to the Slurm command used for manipulating existing jobs. You may want to verify if `scontrol` is provided at that path or determine its actual location (`which scontrol`).
 
-Change directory to `eessi-bot-software-layer` (which was created by cloning the repository in Step 5.4 - either the original one from EESSI or your fork). Then, simply run the bot by executing
+# Instructions to run the bot components
+
+The bot consists of three components, the Smee client, the event handler and the job manager. Running the Smee client was explained in [Step 1](#step1).
+
+## <a name="step6.1"></a>Step 6.1: Running the event handler
+As the event handler may run for a long time, it is adviced to run it in a `screen` or `tmux` session.
+
+The event handler is provided by the Python script `eessi_bot_software_layer.py`.
+Change directory to `eessi-bot-software-layer` (which was created by cloning the
+repository in [Step 5.4](#step5.4) - either the original one from EESSI or your fork).
+Then, simply run the event handler by executing
 ```
 ./run.sh
 ```
+If multiple instances on the `bot machine` are being executed, you may need to run the event handler and the Smee client with a different port (default is 3000). The event handler can receive events on a different port by adding the parameter `--port PORTNUMBER`, for example,
+```
+./run.sh --port 3030
+```
+See [Step 1](#step1) for telling the Smee client on which port the event handler receives events.
 
-Note, if you run the bot on a frontend of a cluster with multiple frontends make sure that both the Smee client and the bot run on the same machine.
+The event handler writes log information to the file `pyghee.log`.
 
-The bot will log events into the file `pyghee.log`.
+Note, if you run the bot on a frontend of a cluster with multiple frontends make sure that both the Smee client and the event handler run on the same machine.
 
-## Testing EESSI bot
+## <a name="step6.2"></a>Step 6.2: Running the job manager
+As the job manager may run for a long time, it is adviced to run it in a `screen` or `tmux` session.
 
-The easiest test may be a change -- creating a branch, committing a change, creating a pull request, etc -- to one of the repositories you have selected when installing the app in Step 3. Which events may be forwarded depends on which events you have subscribed the app to when you registered the app in Step 2.
+The job manager is provided by the Python script `eessi_bot_job_manager_layer.py`. You can run the job manager from the directory `eessi-bot-software-layer` simply by
+
+```
+./job_manager.sh
+```
+
+It will run in an infinite loop monitoring jobs and acting on their state changes.
+
+If you want to control how the job manager works, you can add two parameters:
+|Option|Argument|
+|------|--------|
+|`-i` / `--max-manager-iterations`|Any number _z_: _z_ < 0 - run the main loop indefinitely, _z_ == 0 - don't run the main loop, _z_ > 0 - run the main loop _z_ times|
+|`-j` / `--jobs`|Comma-separated list of job ids the job manager shall process. All other jobs will be ignored.|
+
+An example command would be
+
+```
+./job_manager.sh -i 1 -j 2222
+```
+to run the main loop exactly once for job `2222`.
+
+The job manager writes log information to the file `eessi_bot_job_manager.log`.
+
+The job manager can run on a different machine than the event handler as long as both have access to the same shared filesystem.
+
+# Example pull request on software-layer
+
+Now that the bot is running on your cluster, we want to provide a little demo about how to use it to add a new package to the software layer. We assume that you have forked [EESSI/software-layer](https://github.com/EESSI/software-layer) to `YOU_1/software-layer`, and then forked `YOU_1/software-layer` to `YOU_2/software-layer`.
+
+Clone into the second fork and create a new branch:
+
+```
+git clone https://github.com/YOU_2/software-layer
+cd software-layer
+git branch add-CaDiCaL-9.3.0
+git checkout add-CaDiCaL-9.3.0
+```
+
+Open `EESSI-pilot-install-software.sh` and add the section
+
+```
+export CaDiCaL_EC="CaDiCaL-1.3.0-GCC-9.3.0.eb"
+echo ">> Installing ${CaDiCaL_EC}..."
+ok_msg="${CaDiCaL_EC} installed, let's solve some problems!"
+fail_msg="Installation of ${CaDiCaL_EC} failed, that's a pity..."
+$EB ${CaDiCaL_EC} --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+```
+
+just before the line
+```
+echo ">> Creating/updating Lmod cache..."
+```
+
+Open `eessi-2021.12.yml` and append the section
+
+```
+  CaDiCaL:
+     toolchains:
+       GCC-9.3.0:
+         versions: ['1.3.0']
+```
+
+Commit the changes and push them to `YOU_1/software-layer`. Create the pull request by opening the link shown by `git push`. Make sure that you request to merge into `YOU_1/software-layer` - your bot receives events for this repository only (and while you experiment you may not wish to create too much noise on EESSI's software-layer repository).
+
+At first, the page for the pull request will look like normal pull request. The event handler will already have received an event, but it will wait until the label `bot:build` is set for the pull request.
+
+Add the label `bot:build`. Now, the event handler will submit jobs - one for each target architecture. For each submitted job it will add a comment such as
+
+IMAGE-SCREENSHOT
+
+The jobs are submitted with the parameter `--hold`. They will not start immediately, but rather are required to be released explicitly by the job manager. This can be very useful to control the processing of jobs, for example, when developing the EESSI bot components. If you want to control the execution, the job manager shall not run in an endless loop.
+
+Next the job manager notes the submitted job(s), releases them and updates the comments corresponding to the released jobs. An example update could look like this
+
+IMAGE-SCREENSHOT
+
+When the job has finished, the job manager analyses the result of job (checking if no missing modules were found and if a tarball was generated) and updates the job's comment in the PR. An example update could look like (in case of success)
+
+IMAGE-SCREENSHOT
+
+or in case of failure
+
+IMAGE-SCREENSHOT
+

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -1,8 +1,8 @@
 # Also see documentation at https://github.com/EESSI/eessi-bot-software-layer/blob/main/README.md#step5.5
 
 [github]
-# replace '199740' with the ID of your GitHub App
-app_id = 199740
+# replace '123456' with the ID of your GitHub App; see https://github.com/settings/apps
+app_id = 123456
 
 # a short (!) name for your app instance that can be used for example
 #   when adding/updating a comment to a PR
@@ -14,11 +14,11 @@ app_id = 199740
 #      potentially publicly accessible GitHub pages.
 app_name = MY-bot
 
-# replace '25669742' with the ID of the installation of your GitHub App
+# replace '12345678' with the ID of the installation of your GitHub App
 #   (can be derived by creating an event and then checking for the list
 #   of sent events and its payload either via the Smee channel's web page
 #   or via the Advanced section of your GitHub App on github.com)
-installation_id = 25669742
+installation_id = 12345678
 
 # path to the private key that was generated when the GitHub App was registered
 private_key = PATH_TO_PRIVATE_KEY

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -1,9 +1,13 @@
 [github]
-# replace with ID of your GitHub App
+# replace '199740' with the ID of your GitHub App
 app_id = 199740
-# replace with ID of the installation of your GitHub App (can be derived by
-#   creating an event and then checking for the list of sent events and
-#   its extensive log of attributes; if not by any other easier means)
+# a name for your app instance that can be used for example when adding/updating
+#   a comment to a PR
+app_name = "MY EESSI bot instance on SYSTEM"
+# replace '25669742' with the ID of the installation of your GitHub App
+#   (can be derived by creating an event and then checking for the list
+#   of sent events and its extensive log of attributes; if not by any
+#   other easier means)
 installation_id = 25669742
 private_key = PATH_TO_PRIVATE_KEY_FOR_YOUR_GITHUB_APP
 
@@ -23,7 +27,22 @@ poll_command = /usr/bin/squeue
 # polling interval in seconds
 poll_interval = 10
 
+[common_job_params]
+# parameters to be added to all job submissions
+slurm_params = "--hold"
+
 [architecturetargets]
 # defines both for which architectures the bot will build
 #   and what submission parameters shall be used
 arch_target_map = { "linux/x86_64/intel/haswell": "--constraint shape=c4.2xlarge", "linux/x86_64/amd/zen2": "--constraint shape=c5a.2xlarge" }
+
+[job_monitor]
+# directory where job monitor stores information about jobs to be tracked
+#   e.g. as symbolic link JOBID -> directory to job
+job_ids_dir = PATH_TO_DIRECTORY_STORING_JOB_IDS
+# default value for command line parameter max_monitor_iterations
+# max_monitor_iterations values and how the loop behaves
+#   < 0: run loop indefinitely
+#  == 0: don't run loop
+#   > 0: run loop max_monitor_iterations times
+max_monitor_iterations_default = -1

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -1,3 +1,4 @@
+# Also see documentation at https://github.com/EESSI/eessi-bot-software-layer/blob/main/README.md#step5.5
 [github]
 # replace '199740' with the ID of your GitHub App
 app_id = 199740
@@ -5,47 +6,43 @@ app_id = 199740
 #   when adding/updating a comment to a PR
 # (!) a short yet descriptive name is preferred because it appears in
 #   comments to the PR
+# for example, the name could include the name of the cluster the bot
+#   runs on and the username which runs the bot
 app_name = "MY-bot"
 # replace '25669742' with the ID of the installation of your GitHub App
 #   (can be derived by creating an event and then checking for the list
-#   of sent events and its extensive log of attributes; if not by any
-#   other easier means)
+#   of sent events and its payload either via the Smee channel's web page
+#   or via the Advanced section of your GitHub App on github.com)
 installation_id = 25669742
-private_key = PATH_TO_PRIVATE_KEY_FOR_YOUR_GITHUB_APP
+# path to the private key that was generated when the GitHub App was registered
+private_key = PATH_TO_PRIVATE_KEY
 
 [buildenv]
 # directory under which the bot prepares directories per job
-#   structure created is as follows: EVENT_ID/RUN_HASH/EESSI_VERSION/OS+SUBDIR
-jobs_base_dir = /mnt/shared/home/trz42/jobs
+#   structure created is as follows: YYYY.MM/pr_PR_NUMBER/event_EVENT_ID/run_RUN_NUMBER/OS+SUBDIR
+jobs_base_dir = $HOME/jobs
 # PATH to temporary directory on build node ... ends up being used for
 #   EESSI_TMPDIR --> /tmp/$USER/EESSI
 local_tmp = /tmp/$USER/EESSI
 # name of the job script used for building an EESSI stack
-build_job_script = FULL_PATH_TO_bot_repo/scripts/build_with_EESSI_install.slurm
+build_job_script = PATH_TO_EESSI_BOT/scripts/eessi-bot-build.slurm
 # full path to the job submission command
 submit_command = /usr/bin/sbatch
-# full path to the job status checking command
-poll_command = /usr/bin/squeue
-# polling interval in seconds
-poll_interval = 10
-
-[common_job_params]
 # parameters to be added to all job submissions
 slurm_params = "--hold"
 
 [architecturetargets]
 # defines both for which architectures the bot will build
 #   and what submission parameters shall be used
-arch_target_map = { "linux/x86_64/intel/haswell": "--constraint shape=c4.2xlarge", "linux/x86_64/amd/zen2": "--constraint shape=c5a.2xlarge" }
+arch_target_map = { "linux/x86_64/generic" : "--constraint shape=c4.2xlarge", "linux/x86_64/amd/zen2": "--constraint shape=c5a.2xlarge" }
 
 [job_manager]
 # directory where job manager stores information about jobs to be tracked
 #   e.g. as symbolic link JOBID -> directory to job
-job_ids_dir = PATH_TO_DIRECTORY_STORING_JOB_IDS
-# default value for command line parameter max_manager_iterations
-# max_manager_iterations values and how the loop behaves
-#   < 0: run loop indefinitely
-#  == 0: don't run loop
-#   > 0: run loop max_manager_iterations times
-# default hardcoded as -1
-# max_manager_iterations_default = -1
+job_ids_dir = $HOME/jobs/ids
+# full path to the job status checking command
+poll_command = /usr/bin/squeue
+# polling interval in seconds
+poll_interval = 60
+# full path to the command for manipulating existing jobs
+scontrol_command = /usr/bin/scontrol

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -13,11 +13,15 @@ private_key = PATH_TO_PRIVATE_KEY_FOR_YOUR_GITHUB_APP
 jobs_base_dir = /mnt/shared/home/trz42/jobs
 # PATH to temporary directory on build node ... ends up being used for
 #   EESSI_TMPDIR --> /tmp/$USER/EESSI
-local_tmp = /tmp/USER/EESSI
+local_tmp = /tmp/$USER/EESSI
 # name of the job script used for building an EESSI stack
 build_job_script = FULL_PATH_TO_bot_repo/scripts/build_with_EESSI_install.slurm
 # full path to the job submission command
 submit_command = /usr/bin/sbatch
+# full path to the job status checking command
+poll_command = /usr/bin/squeue
+# polling interval in seconds
+poll_interval = 10
 
 [architecturetargets]
 # defines both for which architectures the bot will build

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -1,9 +1,11 @@
 [github]
 # replace '199740' with the ID of your GitHub App
 app_id = 199740
-# a name for your app instance that can be used for example when adding/updating
-#   a comment to a PR
-app_name = "MY EESSI bot instance on SYSTEM"
+# a short (!) name for your app instance that can be used for example
+#   when adding/updating a comment to a PR
+# (!) a short yet descriptive name is preferred because it appears in
+#   comments to the PR
+app_name = "MY-bot"
 # replace '25669742' with the ID of the installation of your GitHub App
 #   (can be derived by creating an event and then checking for the list
 #   of sent events and its extensive log of attributes; if not by any
@@ -36,14 +38,14 @@ slurm_params = "--hold"
 #   and what submission parameters shall be used
 arch_target_map = { "linux/x86_64/intel/haswell": "--constraint shape=c4.2xlarge", "linux/x86_64/amd/zen2": "--constraint shape=c5a.2xlarge" }
 
-[job_monitor]
-# directory where job monitor stores information about jobs to be tracked
+[job_manager]
+# directory where job manager stores information about jobs to be tracked
 #   e.g. as symbolic link JOBID -> directory to job
 job_ids_dir = PATH_TO_DIRECTORY_STORING_JOB_IDS
-# default value for command line parameter max_monitor_iterations
-# max_monitor_iterations values and how the loop behaves
+# default value for command line parameter max_manager_iterations
+# max_manager_iterations values and how the loop behaves
 #   < 0: run loop indefinitely
 #  == 0: don't run loop
-#   > 0: run loop max_monitor_iterations times
+#   > 0: run loop max_manager_iterations times
 # default hardcoded as -1
-# max_monitor_iterations_default = -1
+# max_manager_iterations_default = -1

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -45,4 +45,5 @@ job_ids_dir = PATH_TO_DIRECTORY_STORING_JOB_IDS
 #   < 0: run loop indefinitely
 #  == 0: don't run loop
 #   > 0: run loop max_monitor_iterations times
-max_monitor_iterations_default = -1
+# default hardcoded as -1
+# max_monitor_iterations_default = -1

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -1,48 +1,82 @@
 # Also see documentation at https://github.com/EESSI/eessi-bot-software-layer/blob/main/README.md#step5.5
+
 [github]
 # replace '199740' with the ID of your GitHub App
 app_id = 199740
+
 # a short (!) name for your app instance that can be used for example
 #   when adding/updating a comment to a PR
 # (!) a short yet descriptive name is preferred because it appears in
 #   comments to the PR
 # for example, the name could include the name of the cluster the bot
 #   runs on and the username which runs the bot
+# NOTE avoid putting an actual username here as it will be visible on
+#      potentially publicly accessible GitHub pages.
 app_name = "MY-bot"
+
 # replace '25669742' with the ID of the installation of your GitHub App
 #   (can be derived by creating an event and then checking for the list
 #   of sent events and its payload either via the Smee channel's web page
 #   or via the Advanced section of your GitHub App on github.com)
 installation_id = 25669742
+
 # path to the private key that was generated when the GitHub App was registered
 private_key = PATH_TO_PRIVATE_KEY
 
+
 [buildenv]
+# name of the job script used for building an EESSI stack
+build_job_script = PATH_TO_EESSI_BOT/scripts/eessi-bot-build.slurm
+
+# it may happen that we need to customize some CVMFS configuration
+#   the value of cvmfs_customizations is a dictionary which maps a file
+#   name to an entry that needs to be added to that file
+cvmfs_customizations = { "/etc/cvmfs/default.local": "CVMFS_HTTP_PROXY=\"http://PROXY_DNS_NAME:3128|http://PROXY_IP_ADDRESS:3128\"" }
+
+# if compute nodes have no internet connection, we need to set http(s)_proxy
+#   or commands such as pip3 cannot download software from package repositories
+#   for example, the temporary EasyBuild is installed via pip3 first
+http_proxy = http://PROXY_DNS:3128/
+https_proxy = http://PROXY_DNS:3128/
+
 # directory under which the bot prepares directories per job
 #   structure created is as follows: YYYY.MM/pr_PR_NUMBER/event_EVENT_ID/run_RUN_NUMBER/OS+SUBDIR
 jobs_base_dir = $HOME/jobs
+
 # PATH to temporary directory on build node ... ends up being used for
-#   EESSI_TMPDIR --> /tmp/$USER/EESSI
+#     for example, EESSI_TMPDIR --> /tmp/$USER/EESSI
+#   escaping variables with '\' delays expansion to the start of the
+#     build_job_script; this can be used for referencing environment
+#     variables that are only set inside a Slurm job
 local_tmp = /tmp/$USER/EESSI
-# name of the job script used for building an EESSI stack
-build_job_script = PATH_TO_EESSI_BOT/scripts/eessi-bot-build.slurm
+
+# parameters to be added to all job submissions
+# NOTE do not quote parameter string. Quotes are retained when reading in config and
+#      then the whole 'string' is recognised as a single parameter.
+# NOTE 2 '--get-user-env' may be needed on systems where the job's environment needs
+#        to be initialised as if it is for a login shell.
+slurm_params = "--hold"
+
 # full path to the job submission command
 submit_command = /usr/bin/sbatch
-# parameters to be added to all job submissions
-slurm_params = "--hold"
+
 
 [architecturetargets]
 # defines both for which architectures the bot will build
 #   and what submission parameters shall be used
 arch_target_map = { "linux/x86_64/generic" : "--constraint shape=c4.2xlarge", "linux/x86_64/amd/zen2": "--constraint shape=c5a.2xlarge" }
 
+
 [job_manager]
 # directory where job manager stores information about jobs to be tracked
 #   e.g. as symbolic link JOBID -> directory to job
 job_ids_dir = $HOME/jobs/ids
+
 # full path to the job status checking command
 poll_command = /usr/bin/squeue
+
 # polling interval in seconds
 poll_interval = 60
+
 # full path to the command for manipulating existing jobs
 scontrol_command = /usr/bin/scontrol

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -43,6 +43,13 @@ https_proxy = http://PROXY_DNS:3128/
 #   structure created is as follows: YYYY.MM/pr_PR_NUMBER/event_EVENT_ID/run_RUN_NUMBER/OS+SUBDIR
 jobs_base_dir = $HOME/jobs
 
+# configure environment
+#   list of comma-separated modules to be loaded by build_job_script
+#   useful/needed if some tool is not provided as system-wide package
+#   (read by bot and handed over to build_job_script via parameter
+#   --load-modules)
+load_modules =
+
 # PATH to temporary directory on build node ... ends up being used for
 #     for example, EESSI_TMPDIR --> /tmp/$USER/EESSI
 #   escaping variables with '\' delays expansion to the start of the

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -12,7 +12,7 @@ app_id = 199740
 #   runs on and the username which runs the bot
 # NOTE avoid putting an actual username here as it will be visible on
 #      potentially publicly accessible GitHub pages.
-app_name = "MY-bot"
+app_name = MY-bot
 
 # replace '25669742' with the ID of the installation of your GitHub App
 #   (can be derived by creating an event and then checking for the list
@@ -55,7 +55,7 @@ local_tmp = /tmp/$USER/EESSI
 #      then the whole 'string' is recognised as a single parameter.
 # NOTE 2 '--get-user-env' may be needed on systems where the job's environment needs
 #        to be initialised as if it is for a login shell.
-slurm_params = "--hold"
+slurm_params = --hold
 
 # full path to the job submission command
 submit_command = /usr/bin/sbatch

--- a/connections/github.py
+++ b/connections/github.py
@@ -33,3 +33,7 @@ def get_instance():
     if not _gh or (_token and datetime.datetime.utcnow() > _token.expires_at):
         _gh = connect()
     return _gh
+
+def token():
+    global _token
+    return _token

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -242,7 +242,8 @@ class EESSIBotSoftwareLayerJobManager:
         gh = github.get_instance()
 
         # set some variables for accessing work dir of job
-        job_ids_dir = config.get_section('job_manager').get('job_ids_dir')
+        job_manager = config.get_section('job_manager')
+        job_ids_dir = job_manager.get('job_ids_dir')
         submitted_jobs_dir = os.path.join(job_ids_dir,'submitted')
         job_dir = os.path.join(submitted_jobs_dir, finished_job['jobid'])
         sym_dst = os.readlink(job_dir)
@@ -418,14 +419,14 @@ def main():
     poll_command  = 'false'
     job_ids_dir = ''
     if max_iter != 0:
-        buildenv = config.get_section('buildenv')
-        poll_interval = int(buildenv.get('poll_interval') or 0)
+        job_manager = config.get_section('job_manager')
+        job_ids_dir = job_manager.get('job_ids_dir')
+        submitted_jobs_dir = os.path.join(job_ids_dir,'submitted')
+        poll_command = job_manager.get('poll_command') or false
+        poll_interval = int(job_manager.get('poll_interval') or 0)
         if poll_interval <= 0:
             poll_interval = 60
-        poll_command = buildenv.get('poll_command') or false
-        scontrol_command = buildenv.get('scontrol_command') or false
-        job_ids_dir = config.get_section('job_manager').get('job_ids_dir')
-        submitted_jobs_dir = os.path.join(job_ids_dir,'submitted')
+        scontrol_command = job_manager.get('scontrol_command') or false
         mkdir(submitted_jobs_dir)
 
     # who am i

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -446,7 +446,7 @@ def main():
         log("job manager main loop: new_jobs='%s'" % ','.join(new_jobs), job_manager.logfile)
         # process new jobs
         for nj in new_jobs:
-            if nj in job_manager.job_filter: 
+            if not job_manager.job_filter or nj in job_manager.job_filter: 
                 job_manager.process_new_job(current_jobs[nj])
             #else:
             #    log("job manager main loop: skipping new job %s due to parameter '--jobs %s'" % (nj,opts.jobs), job_manager.logfile)
@@ -455,7 +455,7 @@ def main():
         log("job manager main loop: finished_jobs='%s'" % ','.join(finished_jobs), job_manager.logfile)
         # process finished jobs
         for fj in finished_jobs:
-            if fj in job_manager.job_filter: 
+            if not job_manager.job_filter or fj in job_manager.job_filter: 
                 job_manager.process_finished_job(known_jobs[fj])
             #else:
             #    log("job manager main loop: skipping finished job %s due to parameter '--jobs %s'" % (fj,opts.jobs), job_manager.logfile)

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -205,9 +205,8 @@ class EESSIBotSoftwareLayerJobManager:
                 issue_comment = pr.get_issue_comment(int(new_job['comment_id']))
                 original_body = issue_comment.body
                 dt = datetime.now(timezone.utc)
-                update = '\n|%s|released|symlk `%s`|' % (
-                        dt.strftime("%b %d %X %Z %Y"),
-                        symlink_source)
+                update = '\n|%s|released|job awaits launch by Slurm scheduler|' % (
+                        dt.strftime("%b %d %X %Z %Y"))
                 issue_comment.edit(original_body + update)
             else:
                 log("process_new_job(): did not obtain/find a comment for job '%s'" % new_job['jobid'], self.logfile)

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -415,18 +415,20 @@ def main():
 
     max_iter = int(opts.max_manager_iterations)
     # retrieve some settings from app.cfg
-    poll_interval = 0
-    poll_command  = 'false'
     job_ids_dir = ''
+    submitted_jobs_dir = ''
+    poll_command  = 'false'
+    poll_interval = 0
+    scontrol_command = ''
     if max_iter != 0:
-        job_manager = config.get_section('job_manager')
-        job_ids_dir = job_manager.get('job_ids_dir')
+        job_mgr = config.get_section('job_manager')
+        job_ids_dir = job_mgr.get('job_ids_dir')
         submitted_jobs_dir = os.path.join(job_ids_dir,'submitted')
-        poll_command = job_manager.get('poll_command') or false
-        poll_interval = int(job_manager.get('poll_interval') or 0)
+        poll_command = job_mgr.get('poll_command') or false
+        poll_interval = int(job_mgr.get('poll_interval') or 0)
         if poll_interval <= 0:
             poll_interval = 60
-        scontrol_command = job_manager.get('scontrol_command') or false
+        scontrol_command = job_mgr.get('scontrol_command') or false
         mkdir(submitted_jobs_dir)
 
     # who am i
@@ -438,7 +440,8 @@ def main():
     #   > 0: run loop max_iter times
     # processing may be limited to a list of job ids (see parameter -j --jobs)
     i = 0
-    known_jobs = job_manager.get_known_jobs(submitted_jobs_dir)
+    if max_iter != 0:
+        known_jobs = job_manager.get_known_jobs(submitted_jobs_dir)
     while max_iter < 0 or i < max_iter:
         print("\njob manager main loop: iteration %d" % i)
         print("known_jobs='%s'" % known_jobs)

--- a/eessi_bot_job_monitor.py
+++ b/eessi_bot_job_monitor.py
@@ -10,13 +10,8 @@
 # 
 # EESSI (build) jobs are recognised by
 #  - being submitted in USER_HELD status (sbatch parameter --hold)
-#  - job directory containing a file with a specific name or specific content
 #  - job ids listed in a specific directory (ids being symlinks to job
 #    directories created by EESSI bot)
-#
-# Creating lists of ids
-#  - at startup, scan specific directory and queue for held jobs
-#  - at regular interval, scan specific directory and queue for held jobs
 #
 # author: Kenneth Hoste (@boegel)
 # author: Bob Droege (@bedroge)
@@ -25,164 +20,50 @@
 # license: GPLv2
 #
 
-#import waitress  # likely won't need to listen on ports
 import json
-import thread
+import os
+import re
+import subprocess
+import time
 
-import pandas as pd
-
-from io import StringIO
 from connections import github
 from tools import args, config
-#from tasks.build import build_easystack_from_pr
 
-from pyghee.lib import read_event_from_json
 from pyghee.utils import create_file, log
-
-def process_job_result(pr, event_info, jobid, pr_dir):
-    # structure of directory tree
-    #   jobs_base_dir/YYYY.MM/pr_<id>/event_<id>/run_<id>/target_<cpuarch>
-    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid> - being a symlink to the job dir
-    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid>/slurm-<jobid>.out
-
-    gh = github.get_instance()
-
-    # seems we have to use `base` here (instead of `head`)
-    repo_name = pr.base.repo.full_name
-    log("process_job_result: repo_name %s" % repo_name)
-    repo = gh.get_repo(repo_name)
-    log("process_job_result: pr.number %s" % pr.number)
-    pull_request = repo.get_pull(pr.number)
-
-    job_dir = os.path.join(pr_dir,jobid)
-    sym_dst = os.readlink(job_dir)
-    slurm_out = os.path.join(sym_dst,'slurm-%s.out' % jobid)
-
-    # determine all tarballs that are stored in the job directory (only expecting 1)
-    tarball_pattern = 'eessi-*software-*.tar.gz'
-    eessi_tarballs = glob.glob(os.path.join(sym_dst,tarball_pattern))
-
-    # set some initial values
-    no_missing_modules = False
-    targz_created = False
-
-    # check slurm out for the below strings
-    #     ^No missing modules!$ --> software successfully installed
-    #     ^eessi-2021.12-software-linux-x86_64-intel-haswell-1654294643.tar.gz created!$ --> tarball successfully created
-    if os.path.exists(slurm_out):
-        re_missing_modules = re.compile('^No missing modules!$')
-        re_targz_created = re.compile('^/eessi_bot_job/eessi-.*-software-.*.tar.gz created!$')
-        outfile = open(slurm_out, "r")
-        for line in outfile:
-            if re_missing_modules.match(line):
-                # no missing modules
-                no_missing_modules = True
-            if re_targz_created.match(line):
-                # tarball created
-                targz_created = True
-
-    if no_missing_modules and targz_created and len(eessi_tarballs) == 1:
-        # We've got one tarball and slurm out messages are ok
-        # Prepare a message with information such as (installation status, tarball name, tarball size)
-        comment = 'SUCCESS The build job (directory %s -> %s) went fine:\n' % (job_dir,sym_dst)
-        comment += ' - No missing modules!\n'
-        comment += ' - Tarball with size %.3f GiB available at %s.\n' % (os.path.getsize(eessi_tarballs[0])/2**30,eessi_tarballs[0])
-        comment += '\nAwaiting approval to ingest this into the repository.\n'
-        # report back to PR (just the comment + maybe add a label? (require manual check))
-        pull_request.create_issue_comment(comment)
-    else:
-        # something is not allright:
-        #  - no slurm out or
-        #  - did not find the messages we expect or
-        #  - no tarball or
-        #  - more than one tarball
-        # prepare a message with details about the above conditions and update PR with a comment
-        comment = 'FAILURE The build job (directory %s -> %s) encountered some issues:\n' % (job_dir,sym_dst)
-        if not os.path.exists(slurm_out):
-            # no slurm out ... something went wrong with the job
-            comment += ' - Did not find slurm output file (%s).\n' % slurm_out
-        if not no_missing_modules:
-            # Found slurm out, but doesn't contain message 'No missing modules!'
-            comment += ' - Slurm output file (%s) does not contain pattern: %s.\n' % (slurm_out,re_missing_modules.pattern)
-        if not targz_created:
-            # Found slurm out, but doesn't contain message 'eessi-.*-software-.*.tar.gz created!'
-            comment += ' - Slurm output file (%s) does not contain pattern: %s.\n' % (slurm_out,re_targz_created.pattern)
-        if len(eessi_tarballs) == 0:
-            # no luck, job just seemed to have failed ...
-            comment += ' - No tarball found in %s. (search pattern %s)\n' % (sym_dst,tarball_pattern)
-        if len(eessi_tarballs) > 1:
-            # something's fishy, we only expected a single tar.gz file
-            comment += ' - Found %d tarballs in %s - only 1 expected.\n' % (len(eessi_tarballs),sym_dst)
-        comment += '\nIf a tarball has been created, it might still be ok to approve the pull request (e.g., after receiving additional information from the build host).'
-        # report back to PR (just the comment + maybe add a label? (require manual check))
-        pull_request.create_issue_comment(comment)
 
 
 class EESSIBotSoftwareLayerJobMonitor:
     'main class for (Slurm) job monitor of EESSI bot (separate process)'
 
-    def get_job_ids(self):
+    def get_current_jobs(self, poll_command, username):
+        squeue_cmd = '%s --long --user=%s' % (poll_command,username)
+        log("run squeue command: %s" % squeue_cmd, self.logfile)
+        squeue = subprocess.run(squeue_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        log("squeue output\n%s" % squeue.stdout, self.logfile)
+        # create dictionary of jobs if any with the following information per job:
+        #  jobid, state, nodelist_reason
+        # skip first two lines of output ("range(2,...)")
+        # TODO check for errors of squeue call
+        current_jobs = {}
+        lines = str(squeue.stdout,"UTF-8").rstrip().split('\n')
+        for i in range(2,len(lines)):
+            # assume lines 2 to len(lines) contain jobs
+            job = lines[i].rstrip().split()
+            if len(job) == 9:
+                #print("id %s state %s reason %s" % (job[0], job[4], job[8]))
+                current_jobs[job[0]] = { 'jobid' : job[0], 'state' : job[4], 'reason' : job[8] }
 
-    def check_job_status(self,jobid):
+        return current_jobs
 
+    #known_jobs = job_monitor.get_known_jobs(jobdir)
+    def get_known_jobs(self, jobdir):
+        # find all symlinks resembling job ids (digits only) in jobdir
+        known_jobs = {}
+        if os.path.isdir(jobdir):
+            regex = re.compile('(\d)+')
+            known_jobs = [ { 'jobid' : fname } for fname in os.listdir(jobdir) if regex.match(fname) and os.path.islink(fname) ]
 
-    def handle_issue_comment_event(self, event_info, log_file=None):
-        """
-        Handle adding/removing of comment in issue or PR.
-        """
-        request_body = event_info['raw_request_body']
-        issue_url = request_body['issue']['url']
-        comment_author = request_body['comment']['user']['login']
-        comment_txt = request_body['comment']['body']
-        log("Comment posted in %s by @%s: %s" % (issue_url, comment_author, comment_txt))
-        log("issue_comment event handled!", log_file=log_file)
-
-
-    def handle_installation_event(self, event_info, log_file=None):
-        """
-        Handle installation of app.
-        """
-        request_body = event_info['raw_request_body']
-        user = request_body['sender']['login']
-        action = request_body['action']
-        # repo_name = request_body['repositories'][0]['full_name'] # not every action has that attribute
-        log("App installation event by user %s with action '%s'" % (user,action))
-        log("installation event handled!", log_file=log_file)
-
-
-    def handle_pull_request_label_event(self, event_info, pr):
-        """
-        Handle adding of a label to a pull request.
-        """
-        log("PR labeled")
-
-
-    def handle_pull_request_opened_event(self, event_info, pr):
-        """
-        Handle opening of a pull request.
-        """
-        log("PR opened")
-        build_easystack_from_pr(pr, event_info)
-
-
-    def handle_pull_request_event(self, event_info, log_file=None):
-        """
-        Handle 'pull_request' event
-        """
-        action = event_info['action']
-        gh = github.get_instance()
-        log("repository: '%s'" % event_info['raw_request_body']['repository']['full_name'] )
-        pr = gh.get_repo(event_info['raw_request_body']['repository']['full_name']).get_pull(event_info['raw_request_body']['pull_request']['number'])
-        log("PR data: %s" % pr)
-
-        handler_name = 'handle_pull_request_%s_event' % action
-        if hasattr(self, handler_name):
-            handler = getattr(self, handler_name)
-            log("Handling PR action '%s' for PR #%d..." % (action, pr.number))
-            handler(event_info, pr)
-        else:
-            log("No handler for PR action '%s'" % action)
-
+        return known_jobs
 
 def main():
     """Main function."""
@@ -190,72 +71,62 @@ def main():
     config.read_file("app.cfg")
     github.connect()
 
-    if opts.file:
-        event = read_event_from_json(opts.file)
-        event_info = get_event_info(event)
-        handle_event(event_info)
-    elif opts.cron:
-        log("Running in cron mode")
-    else:
-        # Run as web app
-        app = create_app(klass=EESSIBotSoftwareLayer)
-        log("EESSI bot for software layer started!")
-        waitress.serve(app, listen='*:%s' % opts.port)
+    job_monitor = EESSIBotSoftwareLayerJobMonitor()
+    job_monitor.logfile = os.path.join(os.getcwd(), 'eessi_bot_job_monitor.log')
+
+    # main loop (first sketch)
+    #  get status of jobs (user_held,pending,running,"finished")
+    #    get list of current jobs (squeue -u ...)
+    #    (for now just assume there are non) remove non-bot jobs
+    #    compare with known list of known jobs
+    #      flag non-existing bot jobs (assumed to have finished) for processing results
+    #    (for now assume all new jobs are bot jobs) determine if "new" jobs belong to the bot
+    #      flag "new" bot jobs for releasing
+    #  process status changes of bot jobs (initial list of states)
+    #    unknown -> user_held: release job & update status
+    #  configured?
+    #    user_held -> pending: update status (queue position)
+    #    pending -> running: update status (start time, end time)
+    #    running -> finished: update status & provide result summary
+
+    max_iter = int(opts.max_monitor_iterations)
+    # retrieve some settings from app.cfg
+    poll_interval = 0
+    poll_command  = 'false'
+    job_ids_dir = ''
+    if max_iter != 0:
+        buildenv = config.get_section('buildenv')
+        poll_interval = int(buildenv.get('poll_interval') or 0)
+        if poll_interval <= 0:
+            poll_interval = 60
+        poll_command = buildenv.get('poll_command') or false
+        jobdir = config.get_section('job_monitor').get('job_ids_dir')
+
+    # who am i
+    username = os.getlogin()
+
+    # max_iter
+    #   < 0: run loop indefinitely
+    #  == 0: don't run loop
+    #   > 0: run loop max_iter times
+    # TODO should we also have the ability to only process one new job? to ease debugging?
+    i = 0
+    known_jobs = job_monitor.get_known_jobs(jobdir)
+    print("known_jobs='%s'" % known_jobs)
+    while max_iter < 0 or i < max_iter:
+        current_jobs = job_monitor.get_current_jobs(poll_command,username)
+        print("current_jobs='%s'" % current_jobs)
+        #new_jobs = job.monitor.determine_new_jobs(known_jobs, current_jobs)
+        # TODO process new jobs
+        #finished_jobs = job.monitor.determine_finished_jobs(known_jobs, current_jobs)
+        # TODO process finished jobs
+
+        known_jobs = current_jobs
+        # sleep poll_interval seconds (only if at least one more iteration)
+        if max_iter < 0 or i+1 < max_iter:
+            time.sleep(poll_interval)
+        i = i + 1
 
 if __name__ == '__main__':
     main()
 
-
-
-
-    # check status for submitted_jobs every N seconds
-    poll_interval = int(config.get_section('buildenv').get('poll_interval') or 0)
-    if poll_interval <= 0:
-        poll_interval = 60
-    poll_command = config.get_section('buildenv').get('poll_command')
-    # the below method works if the poll command is 'squeue'
-    jobs_to_be_checked = submitted_jobs.copy()
-    while len(jobs_to_be_checked) > 0:
-        # initial pause/sleep
-        time.sleep(poll_interval)
-        # check status of all jobs_to_be_checked
-        #   - handle finished jobs
-        #   - update jobs_to_be_checked if any job finished
-        job_list_str = ','.join(jobs_to_be_checked)
-        # TODO instead of '--long' specify explicitly which columns shall be shown
-        squeue_cmd = '%s --long --jobs=%s' % (poll_command,job_list_str)
-        log("run squeue command: %s" % squeue_cmd)
-        squeue = subprocess.run(squeue_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        # cases
-        # (1) no job returned -> all finished -> check result for each, update jobs_to_be_checked
-        # (2) some/not all jobs returned -> may check status (to detect potential issues), check result for jobs not returned & update jobs_to_be_checked for them
-        # (3) all jobs returned -> may check status (to detect potential issues)
-        log("squeue output: +++%s+++" % squeue.stdout)
-        # TODO add sanity check if any output from command
-        job_table = pd.read_csv(StringIO(squeue.stdout.decode("UTF-8")),delim_whitespace=True,skiprows=1)
-        if len(job_table) == 0:
-            # case (1)
-            log("All jobs seem finished.")
-            for cj in jobs_to_be_checked:
-                log("Processing result of job '%s'." % (cj))
-                process_job_result(pr, event_info, cj, os.path.join(jobs_base_dir, ym, pr_id))
-            jobs_to_be_checked = []
-        elif len(job_table) < len(jobs_to_be_checked):
-            # case (2)
-            #   set A: finished jobs -> check job result, remove from jobs_to_be_checked
-            #   set B: not yet finished jobs -> may check status (to detect potential issues)
-            # set A
-            jtbc_df = pd.DataFrame(jobs_to_be_checked, columns = ["JOBID"], dtype = int)
-            # set A: finished
-            finished = jtbc_df[~jtbc_df["JOBID"].isin(job_table["JOBID"])]
-            log("Some jobs seem finished: '%s'" % (','.join(finished["JOBID"]).tolist()))
-            for fj in finished["JOBID"].tolist():
-                log("Processing result of job '%s'." % fj)
-                process_job_result(pr, event_info, fj, os.path.join(jobs_base_dir, ym, pr_id))
-                jobs_to_be_checked.remove(fj)
-            # set B: not yet finished
-            not_finished = jtbc_df[jtbc_df["JOBID"].isin(job_table["JOBID"])]
-        else:
-            # case (3)
-            #   not yet finished jobs -> may check status (to detect potential issues)
-            log("No job finished yet.")

--- a/eessi_bot_job_monitor.py
+++ b/eessi_bot_job_monitor.py
@@ -62,6 +62,8 @@ class EESSIBotSoftwareLayerJobMonitor:
         if os.path.isdir(jobdir):
             regex = re.compile('(\d)+')
             known_jobs = [ { 'jobid' : fname } for fname in os.listdir(jobdir) if regex.match(fname) and os.path.islink(fname) ]
+        else:
+            print("directory '%s' does not exist -> assuming no jobs known previously" % jobdir)
 
         return known_jobs
 

--- a/eessi_bot_job_monitor.py
+++ b/eessi_bot_job_monitor.py
@@ -55,17 +55,33 @@ class EESSIBotSoftwareLayerJobMonitor:
 
         return current_jobs
 
+
     #known_jobs = job_monitor.get_known_jobs(jobdir)
     def get_known_jobs(self, jobdir):
         # find all symlinks resembling job ids (digits only) in jobdir
         known_jobs = {}
         if os.path.isdir(jobdir):
             regex = re.compile('(\d)+')
-            known_jobs = [ { 'jobid' : fname } for fname in os.listdir(jobdir) if regex.match(fname) and os.path.islink(fname) ]
+            for fname in os.listdir(jobdir):
+                if regex.match(fname) and os.path.islink(fname):
+                    known_jobs[fname] = { 'jobid' : fname }
         else:
             print("directory '%s' does not exist -> assuming no jobs known previously" % jobdir)
 
         return known_jobs
+
+
+    #new_jobs = job.monitor.determine_new_jobs(known_jobs, current_jobs)
+    def determine_new_jobs(self, known_jobs, current_jobs):
+        new_jobs = []
+        return new_jobs
+
+
+    #finished_jobs = job.monitor.determine_finished_jobs(known_jobs, current_jobs)
+    def determine_finished_jobs(self, known_jobs, current_jobs):
+        finished_jobs = []
+        return finished_jobs
+
 
 def main():
     """Main function."""
@@ -118,9 +134,9 @@ def main():
     while max_iter < 0 or i < max_iter:
         current_jobs = job_monitor.get_current_jobs(poll_command,username)
         print("current_jobs='%s'" % current_jobs)
-        #new_jobs = job.monitor.determine_new_jobs(known_jobs, current_jobs)
+        new_jobs = job.monitor.determine_new_jobs(known_jobs, current_jobs)
         # TODO process new jobs
-        #finished_jobs = job.monitor.determine_finished_jobs(known_jobs, current_jobs)
+        finished_jobs = job.monitor.determine_finished_jobs(known_jobs, current_jobs)
         # TODO process finished jobs
 
         known_jobs = current_jobs

--- a/eessi_bot_job_monitor.py
+++ b/eessi_bot_job_monitor.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+#
+# (Slurm) job monitor for the GitHub App for the EESSI project
+#
+# This tool monitors jobs and reports back to the corresponding GitHub
+# pull request to a software-layer repo (origin or fork).
+#
+# It essentially monitors the job queue for EESSI (build) jobs and
+# acts on state changes of these jobs.
+# 
+# EESSI (build) jobs are recognised by
+#  - being submitted in USER_HELD status (sbatch parameter --hold)
+#  - job directory containing a file with a specific name or specific content
+#  - job ids listed in a specific directory (ids being symlinks to job
+#    directories created by EESSI bot)
+#
+# Creating lists of ids
+#  - at startup, scan specific directory and queue for held jobs
+#  - at regular interval, scan specific directory and queue for held jobs
+#
+# author: Kenneth Hoste (@boegel)
+# author: Bob Droege (@bedroge)
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+
+#import waitress  # likely won't need to listen on ports
+import json
+import thread
+
+import pandas as pd
+
+from io import StringIO
+from connections import github
+from tools import args, config
+#from tasks.build import build_easystack_from_pr
+
+from pyghee.lib import read_event_from_json
+from pyghee.utils import create_file, log
+
+def process_job_result(pr, event_info, jobid, pr_dir):
+    # structure of directory tree
+    #   jobs_base_dir/YYYY.MM/pr_<id>/event_<id>/run_<id>/target_<cpuarch>
+    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid> - being a symlink to the job dir
+    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid>/slurm-<jobid>.out
+
+    gh = github.get_instance()
+
+    # seems we have to use `base` here (instead of `head`)
+    repo_name = pr.base.repo.full_name
+    log("process_job_result: repo_name %s" % repo_name)
+    repo = gh.get_repo(repo_name)
+    log("process_job_result: pr.number %s" % pr.number)
+    pull_request = repo.get_pull(pr.number)
+
+    job_dir = os.path.join(pr_dir,jobid)
+    sym_dst = os.readlink(job_dir)
+    slurm_out = os.path.join(sym_dst,'slurm-%s.out' % jobid)
+
+    # determine all tarballs that are stored in the job directory (only expecting 1)
+    tarball_pattern = 'eessi-*software-*.tar.gz'
+    eessi_tarballs = glob.glob(os.path.join(sym_dst,tarball_pattern))
+
+    # set some initial values
+    no_missing_modules = False
+    targz_created = False
+
+    # check slurm out for the below strings
+    #     ^No missing modules!$ --> software successfully installed
+    #     ^eessi-2021.12-software-linux-x86_64-intel-haswell-1654294643.tar.gz created!$ --> tarball successfully created
+    if os.path.exists(slurm_out):
+        re_missing_modules = re.compile('^No missing modules!$')
+        re_targz_created = re.compile('^/eessi_bot_job/eessi-.*-software-.*.tar.gz created!$')
+        outfile = open(slurm_out, "r")
+        for line in outfile:
+            if re_missing_modules.match(line):
+                # no missing modules
+                no_missing_modules = True
+            if re_targz_created.match(line):
+                # tarball created
+                targz_created = True
+
+    if no_missing_modules and targz_created and len(eessi_tarballs) == 1:
+        # We've got one tarball and slurm out messages are ok
+        # Prepare a message with information such as (installation status, tarball name, tarball size)
+        comment = 'SUCCESS The build job (directory %s -> %s) went fine:\n' % (job_dir,sym_dst)
+        comment += ' - No missing modules!\n'
+        comment += ' - Tarball with size %.3f GiB available at %s.\n' % (os.path.getsize(eessi_tarballs[0])/2**30,eessi_tarballs[0])
+        comment += '\nAwaiting approval to ingest this into the repository.\n'
+        # report back to PR (just the comment + maybe add a label? (require manual check))
+        pull_request.create_issue_comment(comment)
+    else:
+        # something is not allright:
+        #  - no slurm out or
+        #  - did not find the messages we expect or
+        #  - no tarball or
+        #  - more than one tarball
+        # prepare a message with details about the above conditions and update PR with a comment
+        comment = 'FAILURE The build job (directory %s -> %s) encountered some issues:\n' % (job_dir,sym_dst)
+        if not os.path.exists(slurm_out):
+            # no slurm out ... something went wrong with the job
+            comment += ' - Did not find slurm output file (%s).\n' % slurm_out
+        if not no_missing_modules:
+            # Found slurm out, but doesn't contain message 'No missing modules!'
+            comment += ' - Slurm output file (%s) does not contain pattern: %s.\n' % (slurm_out,re_missing_modules.pattern)
+        if not targz_created:
+            # Found slurm out, but doesn't contain message 'eessi-.*-software-.*.tar.gz created!'
+            comment += ' - Slurm output file (%s) does not contain pattern: %s.\n' % (slurm_out,re_targz_created.pattern)
+        if len(eessi_tarballs) == 0:
+            # no luck, job just seemed to have failed ...
+            comment += ' - No tarball found in %s. (search pattern %s)\n' % (sym_dst,tarball_pattern)
+        if len(eessi_tarballs) > 1:
+            # something's fishy, we only expected a single tar.gz file
+            comment += ' - Found %d tarballs in %s - only 1 expected.\n' % (len(eessi_tarballs),sym_dst)
+        comment += '\nIf a tarball has been created, it might still be ok to approve the pull request (e.g., after receiving additional information from the build host).'
+        # report back to PR (just the comment + maybe add a label? (require manual check))
+        pull_request.create_issue_comment(comment)
+
+
+class EESSIBotSoftwareLayerJobMonitor:
+    'main class for (Slurm) job monitor of EESSI bot (separate process)'
+
+    def get_job_ids(self):
+
+    def check_job_status(self,jobid):
+
+
+    def handle_issue_comment_event(self, event_info, log_file=None):
+        """
+        Handle adding/removing of comment in issue or PR.
+        """
+        request_body = event_info['raw_request_body']
+        issue_url = request_body['issue']['url']
+        comment_author = request_body['comment']['user']['login']
+        comment_txt = request_body['comment']['body']
+        log("Comment posted in %s by @%s: %s" % (issue_url, comment_author, comment_txt))
+        log("issue_comment event handled!", log_file=log_file)
+
+
+    def handle_installation_event(self, event_info, log_file=None):
+        """
+        Handle installation of app.
+        """
+        request_body = event_info['raw_request_body']
+        user = request_body['sender']['login']
+        action = request_body['action']
+        # repo_name = request_body['repositories'][0]['full_name'] # not every action has that attribute
+        log("App installation event by user %s with action '%s'" % (user,action))
+        log("installation event handled!", log_file=log_file)
+
+
+    def handle_pull_request_label_event(self, event_info, pr):
+        """
+        Handle adding of a label to a pull request.
+        """
+        log("PR labeled")
+
+
+    def handle_pull_request_opened_event(self, event_info, pr):
+        """
+        Handle opening of a pull request.
+        """
+        log("PR opened")
+        build_easystack_from_pr(pr, event_info)
+
+
+    def handle_pull_request_event(self, event_info, log_file=None):
+        """
+        Handle 'pull_request' event
+        """
+        action = event_info['action']
+        gh = github.get_instance()
+        log("repository: '%s'" % event_info['raw_request_body']['repository']['full_name'] )
+        pr = gh.get_repo(event_info['raw_request_body']['repository']['full_name']).get_pull(event_info['raw_request_body']['pull_request']['number'])
+        log("PR data: %s" % pr)
+
+        handler_name = 'handle_pull_request_%s_event' % action
+        if hasattr(self, handler_name):
+            handler = getattr(self, handler_name)
+            log("Handling PR action '%s' for PR #%d..." % (action, pr.number))
+            handler(event_info, pr)
+        else:
+            log("No handler for PR action '%s'" % action)
+
+
+def main():
+    """Main function."""
+    opts = args.parse()
+    config.read_file("app.cfg")
+    github.connect()
+
+    if opts.file:
+        event = read_event_from_json(opts.file)
+        event_info = get_event_info(event)
+        handle_event(event_info)
+    elif opts.cron:
+        log("Running in cron mode")
+    else:
+        # Run as web app
+        app = create_app(klass=EESSIBotSoftwareLayer)
+        log("EESSI bot for software layer started!")
+        waitress.serve(app, listen='*:%s' % opts.port)
+
+if __name__ == '__main__':
+    main()
+
+
+
+
+    # check status for submitted_jobs every N seconds
+    poll_interval = int(config.get_section('buildenv').get('poll_interval') or 0)
+    if poll_interval <= 0:
+        poll_interval = 60
+    poll_command = config.get_section('buildenv').get('poll_command')
+    # the below method works if the poll command is 'squeue'
+    jobs_to_be_checked = submitted_jobs.copy()
+    while len(jobs_to_be_checked) > 0:
+        # initial pause/sleep
+        time.sleep(poll_interval)
+        # check status of all jobs_to_be_checked
+        #   - handle finished jobs
+        #   - update jobs_to_be_checked if any job finished
+        job_list_str = ','.join(jobs_to_be_checked)
+        # TODO instead of '--long' specify explicitly which columns shall be shown
+        squeue_cmd = '%s --long --jobs=%s' % (poll_command,job_list_str)
+        log("run squeue command: %s" % squeue_cmd)
+        squeue = subprocess.run(squeue_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # cases
+        # (1) no job returned -> all finished -> check result for each, update jobs_to_be_checked
+        # (2) some/not all jobs returned -> may check status (to detect potential issues), check result for jobs not returned & update jobs_to_be_checked for them
+        # (3) all jobs returned -> may check status (to detect potential issues)
+        log("squeue output: +++%s+++" % squeue.stdout)
+        # TODO add sanity check if any output from command
+        job_table = pd.read_csv(StringIO(squeue.stdout.decode("UTF-8")),delim_whitespace=True,skiprows=1)
+        if len(job_table) == 0:
+            # case (1)
+            log("All jobs seem finished.")
+            for cj in jobs_to_be_checked:
+                log("Processing result of job '%s'." % (cj))
+                process_job_result(pr, event_info, cj, os.path.join(jobs_base_dir, ym, pr_id))
+            jobs_to_be_checked = []
+        elif len(job_table) < len(jobs_to_be_checked):
+            # case (2)
+            #   set A: finished jobs -> check job result, remove from jobs_to_be_checked
+            #   set B: not yet finished jobs -> may check status (to detect potential issues)
+            # set A
+            jtbc_df = pd.DataFrame(jobs_to_be_checked, columns = ["JOBID"], dtype = int)
+            # set A: finished
+            finished = jtbc_df[~jtbc_df["JOBID"].isin(job_table["JOBID"])]
+            log("Some jobs seem finished: '%s'" % (','.join(finished["JOBID"]).tolist()))
+            for fj in finished["JOBID"].tolist():
+                log("Processing result of job '%s'." % fj)
+                process_job_result(pr, event_info, fj, os.path.join(jobs_base_dir, ym, pr_id))
+                jobs_to_be_checked.remove(fj)
+            # set B: not yet finished
+            not_finished = jtbc_df[jtbc_df["JOBID"].isin(job_table["JOBID"])]
+        else:
+            # case (3)
+            #   not yet finished jobs -> may check status (to detect potential issues)
+            log("No job finished yet.")

--- a/eessi_bot_job_monitor.py
+++ b/eessi_bot_job_monitor.py
@@ -73,14 +73,36 @@ class EESSIBotSoftwareLayerJobMonitor:
 
     #new_jobs = job.monitor.determine_new_jobs(known_jobs, current_jobs)
     def determine_new_jobs(self, known_jobs, current_jobs):
+        # known_jobs is a dictionary: jobid -> {'jobid':jobid}
+        # current_jobs is a dictionary: jobid -> {'jobid':jobid,'state':val,'reason':val}
         new_jobs = []
+        for ckey in current_jobs:
+            if not ckey in known_jobs:
+                new_jobs.append(ckey)
+
         return new_jobs
 
 
     #finished_jobs = job.monitor.determine_finished_jobs(known_jobs, current_jobs)
     def determine_finished_jobs(self, known_jobs, current_jobs):
+        # known_jobs is a dictionary: jobid -> {'jobid':jobid}
+        # current_jobs is a dictionary: jobid -> {'jobid':jobid,'state':val,'reason':val}
         finished_jobs = []
+        for kkey in known_jobs:
+            if not kkey in current_jobs:
+                current_jobs.append(kkey)
+
         return finished_jobs
+
+
+    #job_monitor.process_new_job(current_jobs[nj])
+    def process_new_job(self, new_job):
+        return
+
+
+    #job_monitor.process_finished_job(known_jobs[fj])
+    def process_finished_job(self, finished_job):
+        return
 
 
 def main():
@@ -130,18 +152,27 @@ def main():
     # TODO should we also have the ability to only process one new job? to ease debugging?
     i = 0
     known_jobs = job_monitor.get_known_jobs(jobdir)
-    print("known_jobs='%s'" % known_jobs)
     while max_iter < 0 or i < max_iter:
+        print("\njob monitor main loop: iteration %d" % i)
+        print("known_jobs='%s'" % known_jobs)
         current_jobs = job_monitor.get_current_jobs(poll_command,username)
         print("current_jobs='%s'" % current_jobs)
-        new_jobs = job.monitor.determine_new_jobs(known_jobs, current_jobs)
+        new_jobs = job_monitor.determine_new_jobs(known_jobs, current_jobs)
+        print("new_jobs='%s'" % new_jobs)
         # TODO process new jobs
-        finished_jobs = job.monitor.determine_finished_jobs(known_jobs, current_jobs)
+        for nj in new_jobs:
+            job_monitor.process_new_job(current_jobs[nj])
+        finished_jobs = job_monitor.determine_finished_jobs(known_jobs, current_jobs)
+        print("finished_jobs='%s'" % finished_jobs)
         # TODO process finished jobs
+        for fj in finished_jobs:
+            job_monitor.process_finished_job(known_jobs[fj])
 
         known_jobs = current_jobs
+
         # sleep poll_interval seconds (only if at least one more iteration)
         if max_iter < 0 or i+1 < max_iter:
+            print("sleep %d seconds" % poll_interval)
             time.sleep(poll_interval)
         i = i + 1
 

--- a/eessi_bot_software_layer.py
+++ b/eessi_bot_software_layer.py
@@ -68,7 +68,6 @@ class EESSIBotSoftwareLayer(PyGHee):
         Handle opening of a pull request.
         """
         log("PR opened: waiting for label bot:build")
-        #build_easystack_from_pr(pr, event_info)
 
 
     def handle_pull_request_event(self, event_info, log_file=None):

--- a/eessi_bot_software_layer.py
+++ b/eessi_bot_software_layer.py
@@ -97,7 +97,7 @@ def main():
         # Run as web app
         app = create_app(klass=EESSIBotSoftwareLayer)
         log("EESSI bot for software layer started!")
-        waitress.serve(app, listen='*:%s'%(opts.port))
+        waitress.serve(app, listen='*:%s' % opts.port)
 
 if __name__ == '__main__':
     main()

--- a/eessi_bot_software_layer.py
+++ b/eessi_bot_software_layer.py
@@ -47,11 +47,20 @@ class EESSIBotSoftwareLayer(PyGHee):
         log("installation event handled!", log_file=log_file)
 
 
-    def handle_pull_request_label_event(self, event_info, pr):
+    def handle_pull_request_labeled_event(self, event_info, pr):
         """
         Handle adding of a label to a pull request.
         """
-        log("PR labeled")
+
+        # determine label
+        label = event_info['raw_request_body']['label']['name']
+        log("Process PR labeled event: PR#%s, label '%s'" % (pr.number,label))
+
+        if label == "bot:build":
+            # run function to build software stack
+            build_easystack_from_pr(pr, event_info)
+        else:
+            log("handle_pull_request_labeled_event: no handler for label '%s'" % label)
 
 
     def handle_pull_request_opened_event(self, event_info, pr):

--- a/eessi_bot_software_layer.py
+++ b/eessi_bot_software_layer.py
@@ -67,8 +67,8 @@ class EESSIBotSoftwareLayer(PyGHee):
         """
         Handle opening of a pull request.
         """
-        log("PR opened")
-        build_easystack_from_pr(pr, event_info)
+        log("PR opened: waiting for label bot:build")
+        #build_easystack_from_pr(pr, event_info)
 
 
     def handle_pull_request_event(self, event_info, log_file=None):

--- a/job_manager.sh
+++ b/job_manager.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Usage: run with ./job_manager.sh from directory where eessi-bot-job-manager.py is located
+python3 -m eessi_bot_job_manager "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyGithub
 Waitress
 cryptography
-PyGHee>=0.0.2
+PyGHee>=0.0.3

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Usage: run with ./run.sh from directory where eessi-bot-software-layer.py is located
-python3 -m eessi_bot_software_layer
+python3 -m eessi_bot_software_layer "$@"

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -127,6 +127,28 @@ else
   echo "eessi-bot-build.slurm: no modules to be loaded"
 fi
 
+source init/minimal_eessi_env  # for $EESSI_PILOT_VERSION and $EESSI_OS_TYPE
+
+software_subdir=
+for i in {1..9};
+do
+  echo "attempt $i to determine software_subdir"
+  raw_output=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1)
+  echo "raw output of eessi_software_subdir.py: '$raw_output'"
+  software_subdir=$(echo $raw_output | tail -1 | sed 's/.* //g')
+  echo "software_subdir: '$software_subdir'"
+  # check if software_subdir has the format:
+  #   CPU_FAMILY/ARCH_IDENTIFIER
+  if [[ $software_subdir == *"/"* ]]; then
+    echo "software_subdir seems well formatted"
+    break
+  else
+    n=$((1<<$i))
+    echo "sleep $n secs (using exponential backoff)"
+    sleep $n
+  fi
+done
+
 # run standard EESSI software-layer install script
 #   in compat layer environment inside build container
 ./build_container.sh run ${eessi_tmpdir} \
@@ -135,12 +157,6 @@ fi
 # create tarball for the above build and place it in some specific
 #   directory on shared disk (just in main directory of job)
 #   see https://github.com/EESSI/eessi-bot-software-layer/issues/7
-
-source init/minimal_eessi_env  # for $EESSI_PILOT_VERSION and $EESSI_OS_TYPE
-
-echo "raw output of eessi_software_subdir.py: '$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1)'"
-software_subdir=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1 | tail -1 | sed 's/.* //g')
-echo "software_subdir: '$software_subdir'"
 
 timestamp=$(date +%s)
 

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -44,6 +44,7 @@ while [[ $# -gt 0 ]]; do
   case $1 in
     -g|--generic)
       common_opts="${common_opts} --generic"
+      generic_opt=" --generic"
       shift
       ;;
     -h|--help)
@@ -137,8 +138,8 @@ fi
 
 source init/minimal_eessi_env  # for $EESSI_PILOT_VERSION and $EESSI_OS_TYPE
 
-echo "raw output of eessi_software_subdir.py: '$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py 2>&1)'"
-software_subdir=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py 2>&1 | tail -1 | sed 's/.* //g')
+echo "raw output of eessi_software_subdir.py: '$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1)'"
+software_subdir=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1 | tail -1 | sed 's/.* //g')
 echo "software_subdir: '$software_subdir'"
 
 timestamp=$(date +%s)

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -144,7 +144,7 @@ timestamp=$(date +%s)
 export TGZ=$(printf "eessi-%s-software-%s-%s-%d.tar.gz" ${EESSI_PILOT_VERSION} ${EESSI_OS_TYPE} ${software_subdir//\//-} ${timestamp})
 
 ./build_container.sh run ${eessi_tmpdir} \
-    ./create_tarball.sh ${eessi_tmpdir} ${EESSI_PILOT_VERSION} ${software_subdir} ${TGZ}
+    ./create_tarball.sh ${eessi_tmpdir} ${EESSI_PILOT_VERSION} ${software_subdir} /eessi_bot_job/${TGZ}
 
 # clean up eessi_tmpdir
 # TODO add option to keep it for inspection

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -20,12 +20,60 @@
 #  - arguments: 
 #    - eessi_tmpdir: hand over as argument to script
 
-if [ $# -lt 1 ]; then
-    echo "ERROR: Usage: $0 <EESSI tmp dir (example: /tmp/$USER/EESSI)> <any additional options (example: --generic)>" >&2
-    exit 1
-fi
-eessi_tmpdir=$1
-shift
+display_help() {
+  echo "usage: $0 [OPTIONS]"
+  echo "  -g | --generic               -  instructs script to build for generic architecture target"
+  echo "  -h | --help                  -  display this usage information"
+  echo "  -t | --tmpdir TMPDIR         -  path to tmp directory used by build container"
+  echo "  -x | --http-proxy URL        -  provides URL for the environment variable http_proxy"
+  echo "  -y | --https-proxy URL       -  provides URL for the environment variable https_proxy"
+}
+
+POSITIONAL_ARGS=()
+
+tmpdir=${tmpdir:=}
+http_proxy=${http_proxy:=}
+https_proxy=${https_proxy:=}
+common_opts=
+install_software_opts=
+create_tarball_opts=
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -g|--generic)
+      common_opts="${common_opts} --generic"
+      shift
+      ;;
+    -h|--help)
+      display_help  # Call your function
+      # no shifting needed here, we're done.
+      exit 0
+      ;;
+    -t|--tmpdir)
+      tmpdir="$2"
+      eessi_tmpdir=$tmpdir
+      shift 2
+      ;;
+    -x|--http-proxy)
+      http_proxy="$2"
+      install_software_opts="$install_software_opts --http-proxy $http_proxy"
+      shift 2
+      ;;
+    -y|--https-proxy)
+      https_proxy="$2"
+      install_software_opts="$install_software_opts --https-proxy $https_proxy"
+      shift 2
+      ;;
+    -*|--*)
+      echo "Error: Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)  # No more options
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift
+      ;;
+  esac
+done
 
 echo "Starting eessi-bot-build-slurm.sh"
 
@@ -62,7 +110,8 @@ echo "SINGULARITY_BIND=${SINGULARITY_BIND}"
 
 # run standard EESSI software-layer install script
 #   in compat layer environment inside build container
-./build_container.sh run ${eessi_tmpdir} ./install_software_layer.sh "$@"
+./build_container.sh run ${eessi_tmpdir} \
+    ./install_software_layer.sh $install_software_opts $common_opts "$@"
 
 # create tarball for the above build and place it in some specific
 #   directory on shared disk (just in main directory of job)
@@ -79,5 +128,8 @@ echo "SINGULARITY_BIND=${SINGULARITY_BIND}"
 #timestamp=$(date +%s)
 #export TGZ=$(printf "eessi-%s-software-%s-%s-%d.tar.gz" ${EESSI_PILOT_VERSION} ${EESSI_OS_TYPE} ${software_subdir} ${timestamp})
 ./build_container.sh run ${eessi_tmpdir} \
-    ./create_tarball.sh ${eessi_tmpdir} software /eessi_bot_job "$@"
+    ./create_tarball.sh ${eessi_tmpdir} \
+                        software \
+                        /eessi_bot_job \
+                        $create_tarball_opts $common_opts "$@"
 #    ${EESSI_SOFTWARE_SUBDIR} /eessi_bot_job/${TGZ}

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -25,11 +25,14 @@
 #  - arguments: 
 #    - eessi_tmpdir: hand over as argument to script
 
-if [ $# -ne 1 ]; then
-    echo "ERROR: Usage: $0 <EESSI tmp dir (example: /tmp/$USER/EESSI)>" >&2
+if [ $# -lt 1 ]; then
+    echo "ERROR: Usage: $0 <EESSI tmp dir (example: /tmp/$USER/EESSI)> <any additional options (example: --generic)>" >&2
     exit 1
 fi
 eessi_tmpdir=$1
+shift
+
+echo "Starting eessi-bot-build-slurm.sh"
 
 # bind current working directory to /eessi_bot_job in build container,
 # and also use it as home directory in build container
@@ -37,7 +40,7 @@ export SINGULARITY_HOME="$(pwd):/eessi_bot_job"
 
 # run standard EESSI software-layer install script
 #   in compat layer environment inside build container
-./build_container.sh run ${eessi_tmpdir} ./install_software_layer.sh
+./build_container.sh run ${eessi_tmpdir} ./install_software_layer.sh "$@"
 
 # create tarball for the above build and place it in some specific
 #   directory on shared disk (just in main directory of job)
@@ -54,5 +57,5 @@ export SINGULARITY_HOME="$(pwd):/eessi_bot_job"
 #timestamp=$(date +%s)
 #export TGZ=$(printf "eessi-%s-software-%s-%s-%d.tar.gz" ${EESSI_PILOT_VERSION} ${EESSI_OS_TYPE} ${software_subdir} ${timestamp})
 ./build_container.sh run ${eessi_tmpdir} \
-    ./create_tarball.sh ${eessi_tmpdir} software /eessi_bot_job
+    ./create_tarball.sh ${eessi_tmpdir} software /eessi_bot_job "$@"
 #    ${EESSI_SOFTWARE_SUBDIR} /eessi_bot_job/${TGZ}

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -137,7 +137,9 @@ fi
 
 source init/minimal_eessi_env  # for $EESSI_PILOT_VERSION and $EESSI_OS_TYPE
 
+echo "raw output of eessi_software_subdir.py: '$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py 2>&1)'"
 software_subdir=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py 2>&1 | tail -1 | sed 's/.* //g')
+echo "software_subdir: '$software_subdir'"
 
 timestamp=$(date +%s)
 

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -134,22 +134,17 @@ fi
 # create tarball for the above build and place it in some specific
 #   directory on shared disk (just in main directory of job)
 #   see https://github.com/EESSI/eessi-bot-software-layer/issues/7
-#pwd
-#ls -lisa init/eessi_environment_variables
-# the next line only works as intended if the intended repo is mounted on the host
-#   when building for a repo that is only available via the container and a
-#   custom setup, it is not working
-#EESSI_SILENT=0 source init/eessi_environment_variables
-#echo "eessi-bot-build.slurm: EESSI_SOFTWARE_SUBDIR=${EESSI_SOFTWARE_SUBDIR}="
-#software_subdir=$(echo ${EESSI_SOFTWARE_SUBDIR} | tr '/' '-')
-#echo "eessi-bot-build.slurm: software_subdir=${software_subdir}="
-#timestamp=$(date +%s)
-#export TGZ=$(printf "eessi-%s-software-%s-%s-%d.tar.gz" ${EESSI_PILOT_VERSION} ${EESSI_OS_TYPE} ${software_subdir} ${timestamp})
+
+source init/minimal_eessi_env  # for $EESSI_PILOT_VERSION and $EESSI_OS_TYPE
+
+software_subdir=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py 2>&1 | tail -1 | sed 's/.* //g')
+
+timestamp=$(date +%s)
+
+export TGZ=$(printf "eessi-%s-software-%s-%s-%d.tar.gz" ${EESSI_PILOT_VERSION} ${EESSI_OS_TYPE} ${software_subdir//\//-} ${timestamp})
+
 ./build_container.sh run ${eessi_tmpdir} \
-    ./create_tarball.sh ${eessi_tmpdir} \
-                        software \
-                        /eessi_bot_job \
-                        $create_tarball_opts $common_opts "$@"
+    ./create_tarball.sh ${eessi_tmpdir} ${EESSI_PILOT_VERSION} ${software_subdir} ${TGZ}
 
 # clean up eessi_tmpdir
 # TODO add option to keep it for inspection

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -39,6 +39,10 @@ echo "'$eessi_tmpdir'"
 # and also use it as home directory in build container
 export SINGULARITY_HOME="$(pwd):/eessi_bot_job"
 
+# set tmp directory to deal with possibly too small /tmp
+export SINGULARITY_TMPDIR=$eessi_tmpdir/sing_tmp
+mkdir -p $SINGULARITY_TMPDIR
+
 # if eessi_tmpdir is not starting with '/tmp' map it to '/tmp'
 # rationale: something else than /tmp is used for eessi_tmpdir
 #            if /tmp has some limitations (e.g., size);

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -24,6 +24,7 @@ display_help() {
   echo "usage: $0 [OPTIONS]"
   echo "  -g | --generic               -  instructs script to build for generic architecture target"
   echo "  -h | --help                  -  display this usage information"
+  echo "  -m | --load-modules MODULES  -  load modules before launching build container"
   echo "  -t | --tmpdir TMPDIR         -  path to tmp directory used by build container"
   echo "  -x | --http-proxy URL        -  provides URL for the environment variable http_proxy"
   echo "  -y | --https-proxy URL       -  provides URL for the environment variable https_proxy"
@@ -31,6 +32,7 @@ display_help() {
 
 POSITIONAL_ARGS=()
 
+load_modules=${load_modules:=}
 tmpdir=${tmpdir:=}
 http_proxy=${http_proxy:=}
 https_proxy=${https_proxy:=}
@@ -48,6 +50,10 @@ while [[ $# -gt 0 ]]; do
       display_help  # Call your function
       # no shifting needed here, we're done.
       exit 0
+      ;;
+    -m|--load-modules)
+      load_modules="$2"
+      shift 2
       ;;
     -t|--tmpdir)
       tmpdir="$2"
@@ -107,6 +113,18 @@ then
 fi
 
 echo "SINGULARITY_BIND=${SINGULARITY_BIND}"
+
+# load modules if parameter --load-modules (or environment
+#   variable load_modules) was given
+if [[ ! -z $load_modules ]]; then
+  for m in $(echo $load_modules | tr ',' '\n')
+  do
+    echo "eessi-bot-build.slurm: module load '$m'"
+    module load $m
+  done
+else
+  echo "eessi-bot-build.slurm: no modules to be loaded"
+fi
 
 # run standard EESSI software-layer install script
 #   in compat layer environment inside build container

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -94,7 +94,7 @@ echo "'$eessi_tmpdir'"
 export SINGULARITY_HOME="$(pwd):/eessi_bot_job"
 
 # set tmp directory to deal with possibly too small /tmp
-export SINGULARITY_TMPDIR=$eessi_tmpdir/sing_tmp
+export SINGULARITY_TMPDIR=$eessi_tmpdir/singularity_tmpdir
 mkdir -p $SINGULARITY_TMPDIR
 
 # if eessi_tmpdir is not starting with '/tmp' map it to '/tmp'
@@ -150,4 +150,7 @@ fi
                         software \
                         /eessi_bot_job \
                         $create_tarball_opts $common_opts "$@"
-#    ${EESSI_SOFTWARE_SUBDIR} /eessi_bot_job/${TGZ}
+
+# clean up eessi_tmpdir
+# TODO add option to keep it for inspection
+cd ${eessi_tmpdir} && rm -rf .

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -12,11 +12,6 @@
 # license: GPLv2
 #
 #
-#SBATCH --time 24:00:00
-#SBATCH --nodes 1
-#SBATCH --exclusive
-# make job script unworkable by default ... requires '--constraint ...' on command line
-#SBATCH --constraint shape=unknown
 
 # ASSUMPTIONs:
 #  - running from a job environment on shared disc
@@ -34,9 +29,32 @@ shift
 
 echo "Starting eessi-bot-build-slurm.sh"
 
+echo -n "updating \$eessi_tmpdir: '$eessi_tmpdir' -> "
+# replace any env variable in $eessi_tmpdir with its
+#   current value (e.g., a value that is local to the job)
+eessi_tmpdir=$(envsubst <<< $eessi_tmpdir)
+echo "'$eessi_tmpdir'"
+
 # bind current working directory to /eessi_bot_job in build container,
 # and also use it as home directory in build container
 export SINGULARITY_HOME="$(pwd):/eessi_bot_job"
+
+# if eessi_tmpdir is not starting with '/tmp' map it to '/tmp'
+# rationale: something else than /tmp is used for eessi_tmpdir
+#            if /tmp has some limitations (e.g., size);
+#            the bot job is then provided with a (job-specific)
+#            alternative via the bot's config key local_tmp;
+#            because many downstream scripts assume temporary
+#            storage under /tmp, the alternative is mapped to
+#            /tmp inside the container;
+#            the mapping is only needed if $eessi_tmpdir not
+#            already points to /tmp
+if [[ $eessi_tmpdir != /tmp* ]] ;
+then
+    export SINGULARITY_BIND="$eessi_tmpdir:/tmp"
+fi
+
+echo "SINGULARITY_BIND=${SINGULARITY_BIND}"
 
 # run standard EESSI software-layer install script
 #   in compat layer environment inside build container

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -42,10 +42,17 @@ export SINGULARITY_HOME="$(pwd):/eessi_bot_job"
 # create tarball for the above build and place it in some specific
 #   directory on shared disk (just in main directory of job)
 #   see https://github.com/EESSI/eessi-bot-software-layer/issues/7
-EESSI_SILENT=1 source init/eessi_environment_variables
-software_subdir=$(echo ${EESSI_SOFTWARE_SUBDIR} | tr '/' '-')
-timestamp=$(date +%s)
-export TGZ=$(printf "eessi-%s-software-%s-%s-%d.tar.gz" ${EESSI_PILOT_VERSION} ${EESSI_OS_TYPE} ${software_subdir} ${timestamp})
+#pwd
+#ls -lisa init/eessi_environment_variables
+# the next line only works as intended if the intended repo is mounted on the host
+#   when building for a repo that is only available via the container and a
+#   custom setup, it is not working
+#EESSI_SILENT=0 source init/eessi_environment_variables
+#echo "eessi-bot-build.slurm: EESSI_SOFTWARE_SUBDIR=${EESSI_SOFTWARE_SUBDIR}="
+#software_subdir=$(echo ${EESSI_SOFTWARE_SUBDIR} | tr '/' '-')
+#echo "eessi-bot-build.slurm: software_subdir=${software_subdir}="
+#timestamp=$(date +%s)
+#export TGZ=$(printf "eessi-%s-software-%s-%s-%d.tar.gz" ${EESSI_PILOT_VERSION} ${EESSI_OS_TYPE} ${software_subdir} ${timestamp})
 ./build_container.sh run ${eessi_tmpdir} \
-    ./create_tarball.sh ${eessi_tmpdir} ${EESSI_PILOT_VERSION} \
-    ${EESSI_SOFTWARE_SUBDIR} /eessi_bot_job/${TGZ}
+    ./create_tarball.sh ${eessi_tmpdir} software /eessi_bot_job
+#    ${EESSI_SOFTWARE_SUBDIR} /eessi_bot_job/${TGZ}

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -140,7 +140,7 @@ def build_easystack_from_pr(pr, event_info):
         log("Submit command executed!\nStdout: %s\nStderr: %s" % (submitted.stdout, submitted.stderr))
 
     # TODO: report submitted jobs (incl architecture, ...)
-    comment = 'Submitted %d job(s) on %s (%s)\n' % len(submitted_jobs,app_name)
+    comment = 'Submitted %d job(s) on "%s"\n' % len(submitted_jobs,app_name)
     # repo_name = pr.base.repo.full_name # already set above
     repo = gh.get_repo(repo_name)
     pull_request = repo.get_pull(pr.number)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -152,7 +152,7 @@ def build_easystack_from_pr(pr, event_info):
         git_clone_cmd = ' '.join([
             'git clone',
             'https://github.com/' + repo_name,
-            ' ' + arch_job_dir,
+            arch_job_dir,
         ])
         log("Clone repo by running '%s' in directory '%s'" % (git_clone_cmd,arch_job_dir))
         cloned_repo = subprocess.run(git_clone_cmd,

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -59,6 +59,7 @@ def build_easystack_from_pr(pr, event_info):
     gh = github.get_instance()
     # adopting approach outlined in https://github.com/EESSI/eessi-bot-software-layer/issues/17
     # need to use `base` instead of `head` ... don't need to know the branch name
+    # TODO rename to base_repo_name?
     repo_name = pr.base.repo.full_name
     log("build_easystack_from_pr: pr.base.repo.full_name '%s'" % pr.base.repo.full_name)
 
@@ -144,7 +145,8 @@ def build_easystack_from_pr(pr, event_info):
         log("jobs_base_dir: %s, ym: %s, pr_id: %s, job_id: %s" % (jobs_base_dir,ym,pr_id,job_id))
         os.symlink(job[0], symlink)
         log("Submit command executed!\nStdout: %s\nStderr: %s" % (submitted.stdout, submitted.stderr))
-        # TODO create _bot_job<jobid>.metadata file in submission directory
+
+        # create _bot_job<jobid>.metadata file in submission directory
         bot_jobfile = configparser.ConfigParser()
         bot_jobfile['PR'] = { 'repo' : repo_name, 'pr_number' : pr.number }
         bot_jobfile_path = os.path.join(job[0], '_bot_job%s.metadata' % job_id)
@@ -156,12 +158,12 @@ def build_easystack_from_pr(pr, event_info):
         # obtain arch from job[1] which has the format OS/ARCH
         arch_name = '-'.join(job[1].split('/')[1:])
         job_comment += ' for `%s`' % arch_name
-        job_comment += ' in `%s`\n' % symlink
-        job_comment += '|date|job status|end time|comment|\n'
-        job_comment += '|----------|----------|--------|------------------------|\n'
+        job_comment += ' in job dir `%s`\n' % symlink
+        job_comment += '|date|job status|comment|\n'
+        job_comment += '|----------|----------|------------------------|\n'
 
         dt = datetime.now(timezone.utc)
-        job_comment += '|%s|submitted|Unknown|job waits for release by job manager|' % (dt.strftime("%b %d %X %Z %Y"))
+        job_comment += '|%s|submitted|job waits for release by job manager|' % (dt.strftime("%b %d %X %Z %Y"))
 
         # repo_name = pr.base.repo.full_name # already set above
         repo = gh.get_repo(repo_name)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -17,9 +17,11 @@ from datetime import datetime
 def process_job_result(pr, event_info, jobid, pr_dir):
     # structure of directory tree
     #   jobs_base_dir/YYYY.MM/pr_<id>/event_<id>/run_<id>/target_<cpuarch>
-    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid> - being a link to the job dir
+    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid> - being a symlink to the job dir
     #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid>/slurm-<jobid>.out
+
     gh = github.get_instance()
+
     # seems we have to use `base` here (instead of `head`)
     repo_name = pr.base.repo.full_name
     log("process_job_result: repo_name %s" % repo_name)
@@ -29,7 +31,7 @@ def process_job_result(pr, event_info, jobid, pr_dir):
 
     job_dir = os.path.join(pr_dir,jobid)
     sym_dst = os.readlink(job_dir)
-    slurm_out = os.path.join(sym_dst,'slurm-%s.out' % (jobid))
+    slurm_out = os.path.join(sym_dst,'slurm-%s.out' % jobid)
 
     # determine all tarballs that are stored in the job directory (only expecting 1)
     tarball_pattern = 'eessi-*software-*.tar.gz'
@@ -73,7 +75,7 @@ def process_job_result(pr, event_info, jobid, pr_dir):
         comment = 'FAILURE The build job (directory %s -> %s) encountered some issues:\n' % (job_dir,sym_dst)
         if not os.path.exists(slurm_out):
             # no slurm out ... something went wrong with the job
-            comment += ' - Did not find slurm output file (%s).\n' % (slurm_out)
+            comment += ' - Did not find slurm output file (%s).\n' % slurm_out
         if not no_missing_modules:
             # Found slurm out, but doesn't contain message 'No missing modules!'
             comment += ' - Slurm output file (%s) does not contain pattern: %s.\n' % (slurm_out,re_missing_modules.pattern)
@@ -162,18 +164,18 @@ def build_easystack_from_pr(pr, event_info):
                                      stderr=subprocess.PIPE)
         log("Cloned repo!\nStdout %s\nStderr: %s" % (cloned_repo.stdout,cloned_repo.stderr))
 
-        cmd = 'curl -L https://github.com/%s/pull/%s.patch > %s.patch' % (repo_name,pr.number,pr.number)
-        log("Obtain patch by running '%s' in directory '%s'" % (cmd,arch_job_dir))
-        got_patch = subprocess.run(cmd,
+        curl_cmd = 'curl -L https://github.com/%s/pull/%s.patch > %s.patch' % (repo_name,pr.number,pr.number)
+        log("Obtain patch by running '%s' in directory '%s'" % (curl_cmd,arch_job_dir))
+        got_patch = subprocess.run(curl_cmd,
                                    cwd=arch_job_dir,
                                    shell=True,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         log("Got patch!\nStdout %s\nStderr: %s" % (got_patch.stdout,got_patch.stderr))
 
-        cmd = 'git am %s.patch' % pr.number
-        log("Apply patch by running '%s' in directory '%s'" % (cmd,arch_job_dir))
-        patched = subprocess.run(cmd,
+        git_am_cmd = 'git am %s.patch' % pr.number
+        log("Apply patch by running '%s' in directory '%s'" % (git_am_cmd,arch_job_dir))
+        patched = subprocess.run(git_am_cmd,
                                  cwd=arch_job_dir,
                                  shell=True,
                                  stdout=subprocess.PIPE,
@@ -193,9 +195,16 @@ def build_easystack_from_pr(pr, event_info):
     for job in jobs:
         log("Submit job with '%s %s %s %s' from directory '%s'" % (submit_command, job[2], build_job_script, local_tmp, job[0]))
         # TODO make local_tmp specific to job? to isolate jobs if multiple ones can run on a single node
-        command_line = submit_command + ' ' + job[2] + ' ' + build_job_script + ' ' + local_tmp;
+        command_line = ' '.join([
+            submit_command,
+            job[2],
+            build_job_script,
+            local_tmp,
+        ])
         submitted = subprocess.run(command_line, shell=True, cwd=job[0], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        # parse job id & add it to array of submitted jobs PLUS create a symlink from main pr_<ID> dir to job dir (job[0])
+
+        # sbatch output is 'Submitted batch job JOBID'
+        #   parse job id & add it to array of submitted jobs PLUS create a symlink from main pr_<ID> dir to job dir (job[0])
         job_id = submitted.stdout.split()[3].decode("UTF-8")
         submitted_jobs.append(job_id)
         log("jobs_base_dir: %s, ym: %s, pr_id: %s, job_id: %s" % (jobs_base_dir,ym,pr_id,job_id))
@@ -207,6 +216,7 @@ def build_easystack_from_pr(pr, event_info):
     if poll_interval <= 0:
         poll_interval = 60
     poll_command = config.get_section('buildenv').get('poll_command')
+    # the below method works if the poll command is 'squeue'
     jobs_to_be_checked = submitted_jobs.copy()
     while len(jobs_to_be_checked) > 0:
         # initial pause/sleep
@@ -215,15 +225,16 @@ def build_easystack_from_pr(pr, event_info):
         #   - handle finished jobs
         #   - update jobs_to_be_checked if any job finished
         job_list_str = ','.join(jobs_to_be_checked)
+        # TODO instead of '--long' specify explicitly which columns shall be shown
         squeue_cmd = '%s --long --jobs=%s' % (poll_command,job_list_str)
-        log("run squeue command: %s" % (squeue_cmd))
+        log("run squeue command: %s" % squeue_cmd)
         squeue = subprocess.run(squeue_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # cases
         # (1) no job returned -> all finished -> check result for each, update jobs_to_be_checked
         # (2) some/not all jobs returned -> may check status (to detect potential issues), check result for jobs not returned & update jobs_to_be_checked for them
         # (3) all jobs returned -> may check status (to detect potential issues)
         log("squeue output: +++%s+++" % squeue.stdout)
-        # TODO sanity check if any output from command
+        # TODO add sanity check if any output from command
         job_table = pd.read_csv(StringIO(squeue.stdout.decode("UTF-8")),delim_whitespace=True,skiprows=1)
         if len(job_table) == 0:
             # case (1)
@@ -242,7 +253,7 @@ def build_easystack_from_pr(pr, event_info):
             finished = jtbc_df[~jtbc_df["JOBID"].isin(job_table["JOBID"])]
             log("Some jobs seem finished: '%s'" % (','.join(finished["JOBID"]).tolist()))
             for fj in finished["JOBID"].tolist():
-                log("Processing result of job '%s'." % (fj))
+                log("Processing result of job '%s'." % fj)
                 process_job_result(pr, event_info, fj, os.path.join(jobs_base_dir, ym, pr_id))
                 jobs_to_be_checked.remove(fj)
             # set B: not yet finished

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -80,6 +80,8 @@ def build_easystack_from_pr(pr, event_info):
     # TODO rename to base_repo_name?
     repo_name = pr.base.repo.full_name
     log("build_easystack_from_pr: pr.base.repo.full_name '%s'" % pr.base.repo.full_name)
+    branch_name = pr.base.ref
+    log("build_easystack_from_pr: pr.base.repo.ref '%s'" % pr.base.ref)
 
     jobs = []
     for arch_target,slurm_opt in arch_target_map.items():
@@ -93,6 +95,7 @@ def build_easystack_from_pr(pr, event_info):
         #  NOTE, patching method seems to fail sometimes, using a different method
         #    * patching method
         #      git clone https://github.com/REPO_NAME arch_job_dir
+        #      git checkout BRANCH (is stored as ref for base record in PR)
         #      curl -L https://github.com/REPO_NAME/pull/PR_NUMBER.patch > arch_job_dir/PR_NUMBER.patch
         #    (execute the next one in arch_job_dir)
         #      git am PR_NUMBER.patch
@@ -116,6 +119,18 @@ def build_easystack_from_pr(pr, event_info):
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
         log("Cloned repo!\nStdout %s\nStderr: %s" % (cloned_repo.stdout,cloned_repo.stderr))
+
+        git_checkout_cmd = ' '.join([
+            'git checkout',
+            branch_name,
+        ])
+        log("Checkout branch '%s' by running '%s' in directory '%s'" % (branc
+        checkout_repo = subprocess.run(git_checkout_cmd,
+                                     cwd=arch_job_dir,
+                                     shell=True,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+        log("Checked out branch!\nStdout %s\nStderr: %s" % (checkout_repo.std
 
         curl_cmd = 'curl -L https://github.com/%s/pull/%s.patch > %s.patch' % (repo_name,pr.number,pr.number)
         log("Obtain patch by running '%s' in directory '%s'" % (curl_cmd,arch_job_dir))

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -124,13 +124,13 @@ def build_easystack_from_pr(pr, event_info):
             'git checkout',
             branch_name,
         ])
-        log("Checkout branch '%s' by running '%s' in directory '%s'" % (branc
+        log("Checkout branch '%s' by running '%s' in directory '%s'" % (branch_name,git_checkout_cmd,arch_job_dir))
         checkout_repo = subprocess.run(git_checkout_cmd,
                                      cwd=arch_job_dir,
                                      shell=True,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
-        log("Checked out branch!\nStdout %s\nStderr: %s" % (checkout_repo.std
+        log("Checked out branch!\nStdout %s\nStderr: %s" % (checkout_repo.stdout,checkout_repo.stderr))
 
         curl_cmd = 'curl -L https://github.com/%s/pull/%s.patch > %s.patch' % (repo_name,pr.number,pr.number)
         log("Obtain patch by running '%s' in directory '%s'" % (curl_cmd,arch_job_dir))

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -161,7 +161,7 @@ def build_easystack_from_pr(pr, event_info):
         job_comment += '|----------|----------|--------|------------------------|\n'
 
         dt = datetime.now(timezone.utc)
-        job_comment += '|%s|submitted|Unknown|job waits for release by job monitor|' % (dt.strftime("%b %d %X %Z %Y"))
+        job_comment += '|%s|submitted|Unknown|job waits for release by job manager|' % (dt.strftime("%b %d %X %Z %Y"))
 
         # repo_name = pr.base.repo.full_name # already set above
         repo = gh.get_repo(repo_name)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -184,7 +184,7 @@ def build_easystack_from_pr(pr, event_info):
             slurm_params,
             job[2],
             build_job_script,
-            local_tmp,
+            '--tmpdir', local_tmp,
         ])
         if http_proxy:
             command_line += ' --http-proxy ' + http_proxy

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -121,7 +121,7 @@ def build_easystack_from_pr(pr, event_info):
     submitted_jobs = []
     job_comment = ''
     for job in jobs:
-        log("Submit job with '%s %s %s %s %s' from directory '%s'" % (submit_command, slurm_params, job[2], build_job_script, local_tmp, job[0]))
+        log("Submit job for target %s with '%s %s %s %s %s' from directory '%s'" % (job[1], submit_command, slurm_params, job[2], build_job_script, local_tmp, job[0]))
         # TODO make local_tmp specific to job? to isolate jobs if multiple ones can run on a single node
         command_line = ' '.join([
             submit_command,
@@ -130,6 +130,13 @@ def build_easystack_from_pr(pr, event_info):
             build_job_script,
             local_tmp,
         ])
+        # TODO the handling of generic targets requires a bit knowledge about
+        #      the internals of building the software layer, maybe ok for now,
+        #      but it might be good to think about an alternative
+        # if target contains generic, add ' --generic' to command line
+        if "generic" in job[1]:
+            command_line += ' --generic'
+
         submitted = subprocess.run(
                 command_line,
                 shell=True,

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -5,92 +5,10 @@ import time
 import glob
 import re
 
-import pandas as pd
-
-from io import StringIO
 from connections import github
 from tools import config
 from pyghee.utils import log
 from datetime import datetime
-
-
-def process_job_result(pr, event_info, jobid, pr_dir):
-    # structure of directory tree
-    #   jobs_base_dir/YYYY.MM/pr_<id>/event_<id>/run_<id>/target_<cpuarch>
-    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid> - being a symlink to the job dir
-    #   jobs_base_dir/YYYY.MM/pr_<id>/<jobid>/slurm-<jobid>.out
-
-    gh = github.get_instance()
-
-    # seems we have to use `base` here (instead of `head`)
-    repo_name = pr.base.repo.full_name
-    log("process_job_result: repo_name %s" % repo_name)
-    repo = gh.get_repo(repo_name)
-    log("process_job_result: pr.number %s" % pr.number)
-    pull_request = repo.get_pull(pr.number)
-
-    job_dir = os.path.join(pr_dir,jobid)
-    sym_dst = os.readlink(job_dir)
-    slurm_out = os.path.join(sym_dst,'slurm-%s.out' % jobid)
-
-    # determine all tarballs that are stored in the job directory (only expecting 1)
-    tarball_pattern = 'eessi-*software-*.tar.gz'
-    eessi_tarballs = glob.glob(os.path.join(sym_dst,tarball_pattern))
-
-    # set some initial values
-    no_missing_modules = False
-    targz_created = False
-
-    # check slurm out for the below strings
-    #     ^No missing modules!$ --> software successfully installed
-    #     ^eessi-2021.12-software-linux-x86_64-intel-haswell-1654294643.tar.gz created!$ --> tarball successfully created
-    if os.path.exists(slurm_out):
-        re_missing_modules = re.compile('^No missing modules!$')
-        re_targz_created = re.compile('^/eessi_bot_job/eessi-.*-software-.*.tar.gz created!$')
-        outfile = open(slurm_out, "r")
-        for line in outfile:
-            if re_missing_modules.match(line):
-                # no missing modules
-                no_missing_modules = True
-            if re_targz_created.match(line):
-                # tarball created
-                targz_created = True
-
-    if no_missing_modules and targz_created and len(eessi_tarballs) == 1:
-        # We've got one tarball and slurm out messages are ok
-        # Prepare a message with information such as (installation status, tarball name, tarball size)
-        comment = 'SUCCESS The build job (directory %s -> %s) went fine:\n' % (job_dir,sym_dst)
-        comment += ' - No missing modules!\n'
-        comment += ' - Tarball with size %.3f GiB available at %s.\n' % (os.path.getsize(eessi_tarballs[0])/2**30,eessi_tarballs[0])
-        comment += '\nAwaiting approval to ingest this into the repository.\n'
-        # report back to PR (just the comment + maybe add a label? (require manual check))
-        pull_request.create_issue_comment(comment)
-    else:
-        # something is not allright:
-        #  - no slurm out or
-        #  - did not find the messages we expect or
-        #  - no tarball or
-        #  - more than one tarball
-        # prepare a message with details about the above conditions and update PR with a comment
-        comment = 'FAILURE The build job (directory %s -> %s) encountered some issues:\n' % (job_dir,sym_dst)
-        if not os.path.exists(slurm_out):
-            # no slurm out ... something went wrong with the job
-            comment += ' - Did not find slurm output file (%s).\n' % slurm_out
-        if not no_missing_modules:
-            # Found slurm out, but doesn't contain message 'No missing modules!'
-            comment += ' - Slurm output file (%s) does not contain pattern: %s.\n' % (slurm_out,re_missing_modules.pattern)
-        if not targz_created:
-            # Found slurm out, but doesn't contain message 'eessi-.*-software-.*.tar.gz created!'
-            comment += ' - Slurm output file (%s) does not contain pattern: %s.\n' % (slurm_out,re_targz_created.pattern)
-        if len(eessi_tarballs) == 0:
-            # no luck, job just seemed to have failed ...
-            comment += ' - No tarball found in %s. (search pattern %s)\n' % (sym_dst,tarball_pattern)
-        if len(eessi_tarballs) > 1:
-            # something's fishy, we only expected a single tar.gz file
-            comment += ' - Found %d tarballs in %s - only 1 expected.\n' % (len(eessi_tarballs),sym_dst)
-        comment += '\nIf a tarball has been created, it might still be ok to approve the pull request (e.g., after receiving additional information from the build host).'
-        # report back to PR (just the comment + maybe add a label? (require manual check))
-        pull_request.create_issue_comment(comment)
 
 
 def mkdir(path):
@@ -100,6 +18,9 @@ def mkdir(path):
 
 def build_easystack_from_pr(pr, event_info):
     # retrieving some settings from 'app.cfg' in bot directory
+    # [github]
+    app_name = config.get_section('github').get('app_name')
+
     # [buildenv]
     buildenv = config.get_section('buildenv')
     jobs_base_dir = buildenv.get('jobs_base_dir')
@@ -110,6 +31,10 @@ def build_easystack_from_pr(pr, event_info):
     log("build_job_script '%s'" % build_job_script)
     submit_command = buildenv.get('submit_command')
     log("submit_command '%s'" % submit_command)
+
+    # [common_job_params]
+    common_job_params = config.get_section('common_job_params')
+    slurm_params = common_job_params.get('slurm_params')
 
     # [architecturetargets]
     arch_target_map = json.loads(config.get_section('architecturetargets').get('arch_target_map'))
@@ -192,11 +117,13 @@ def build_easystack_from_pr(pr, event_info):
 
     # Run jobs with the build job submission script
     submitted_jobs = []
+    job_comment = ''
     for job in jobs:
-        log("Submit job with '%s %s %s %s' from directory '%s'" % (submit_command, job[2], build_job_script, local_tmp, job[0]))
+        log("Submit job with '%s %s %s %s %s' from directory '%s'" % (submit_command, slurm_params, job[2], build_job_script, local_tmp, job[0]))
         # TODO make local_tmp specific to job? to isolate jobs if multiple ones can run on a single node
         command_line = ' '.join([
             submit_command,
+            slurm_params,
             job[2],
             build_job_script,
             local_tmp,
@@ -207,58 +134,14 @@ def build_easystack_from_pr(pr, event_info):
         #   parse job id & add it to array of submitted jobs PLUS create a symlink from main pr_<ID> dir to job dir (job[0])
         job_id = submitted.stdout.split()[3].decode("UTF-8")
         submitted_jobs.append(job_id)
+        job_comment += 'OS/ARCH=%s JOBID=%d JOBDIR=%s\n' % (arch_target,job_id,job[0])
         log("jobs_base_dir: %s, ym: %s, pr_id: %s, job_id: %s" % (jobs_base_dir,ym,pr_id,job_id))
         os.symlink(job[0], os.path.join(jobs_base_dir, ym, pr_id, job_id))
         log("Submit command executed!\nStdout: %s\nStderr: %s" % (submitted.stdout, submitted.stderr))
 
-    # check status for submitted_jobs every N seconds
-    poll_interval = int(config.get_section('buildenv').get('poll_interval') or 0)
-    if poll_interval <= 0:
-        poll_interval = 60
-    poll_command = config.get_section('buildenv').get('poll_command')
-    # the below method works if the poll command is 'squeue'
-    jobs_to_be_checked = submitted_jobs.copy()
-    while len(jobs_to_be_checked) > 0:
-        # initial pause/sleep
-        time.sleep(poll_interval)
-        # check status of all jobs_to_be_checked
-        #   - handle finished jobs
-        #   - update jobs_to_be_checked if any job finished
-        job_list_str = ','.join(jobs_to_be_checked)
-        # TODO instead of '--long' specify explicitly which columns shall be shown
-        squeue_cmd = '%s --long --jobs=%s' % (poll_command,job_list_str)
-        log("run squeue command: %s" % squeue_cmd)
-        squeue = subprocess.run(squeue_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        # cases
-        # (1) no job returned -> all finished -> check result for each, update jobs_to_be_checked
-        # (2) some/not all jobs returned -> may check status (to detect potential issues), check result for jobs not returned & update jobs_to_be_checked for them
-        # (3) all jobs returned -> may check status (to detect potential issues)
-        log("squeue output: +++%s+++" % squeue.stdout)
-        # TODO add sanity check if any output from command
-        job_table = pd.read_csv(StringIO(squeue.stdout.decode("UTF-8")),delim_whitespace=True,skiprows=1)
-        if len(job_table) == 0:
-            # case (1)
-            log("All jobs seem finished.")
-            for cj in jobs_to_be_checked:
-                log("Processing result of job '%s'." % (cj))
-                process_job_result(pr, event_info, cj, os.path.join(jobs_base_dir, ym, pr_id))
-            jobs_to_be_checked = []
-        elif len(job_table) < len(jobs_to_be_checked):
-            # case (2)
-            #   set A: finished jobs -> check job result, remove from jobs_to_be_checked
-            #   set B: not yet finished jobs -> may check status (to detect potential issues)
-            # set A
-            jtbc_df = pd.DataFrame(jobs_to_be_checked, columns = ["JOBID"], dtype = int)
-            # set A: finished
-            finished = jtbc_df[~jtbc_df["JOBID"].isin(job_table["JOBID"])]
-            log("Some jobs seem finished: '%s'" % (','.join(finished["JOBID"]).tolist()))
-            for fj in finished["JOBID"].tolist():
-                log("Processing result of job '%s'." % fj)
-                process_job_result(pr, event_info, fj, os.path.join(jobs_base_dir, ym, pr_id))
-                jobs_to_be_checked.remove(fj)
-            # set B: not yet finished
-            not_finished = jtbc_df[jtbc_df["JOBID"].isin(job_table["JOBID"])]
-        else:
-            # case (3)
-            #   not yet finished jobs -> may check status (to detect potential issues)
-            log("No job finished yet.")
+    # TODO: report submitted jobs (incl architecture, ...)
+    comment = 'Submitted %d job(s) on %s (%s)\n' % len(submitted_jobs,app_name)
+    # repo_name = pr.base.repo.full_name # already set above
+    repo = gh.get_repo(repo_name)
+    pull_request = repo.get_pull(pr.number)
+    pull_request.create_issue_comment(comment+job_comment)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -191,14 +191,14 @@ def build_easystack_from_pr(pr, event_info):
         if https_proxy:
             command_line += ' --https-proxy ' + https_proxy
 
-        log("Submit job for target '%s' with '%s' from directory '%s'" % (job[1], command_line, job[0]))
-
         # TODO the handling of generic targets requires a bit knowledge about
         #      the internals of building the software layer, maybe ok for now,
         #      but it might be good to think about an alternative
         # if target contains generic, add ' --generic' to command line
         if "generic" in job[1]:
             command_line += ' --generic'
+
+        log("Submit job for target '%s' with '%s' from directory '%s'" % (job[1], command_line, job[0]))
 
         submitted = subprocess.run(
                 command_line,

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -134,13 +134,16 @@ def build_easystack_from_pr(pr, event_info):
         #   parse job id & add it to array of submitted jobs PLUS create a symlink from main pr_<ID> dir to job dir (job[0])
         job_id = submitted.stdout.split()[3].decode("UTF-8")
         submitted_jobs.append(job_id)
-        job_comment += '* OS/ARCH=%s\n* JOBID=%s\n* JOBDIR=%s\n' % (arch_target,job_id,job[0])
+        job_comment += '|%s|submitted|%s|%s|\n' % (job_id,arch_target,job[0])
         log("jobs_base_dir: %s, ym: %s, pr_id: %s, job_id: %s" % (jobs_base_dir,ym,pr_id,job_id))
         os.symlink(job[0], os.path.join(jobs_base_dir, ym, pr_id, job_id))
         log("Submit command executed!\nStdout: %s\nStderr: %s" % (submitted.stdout, submitted.stderr))
 
     # report submitted jobs (incl architecture, ...)
     comment = 'Submitted %d job(s) on %s\n' % (len(submitted_jobs),app_name)
+    if len(submitted_jobs) > 0:
+        comment += '|job id|job status|os/architecture|job directory|\n'
+        comment += '|------|----------|----------------|------------------------------|\n'
     # repo_name = pr.base.repo.full_name # already set above
     repo = gh.get_repo(repo_name)
     pull_request = repo.get_pull(pr.number)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -32,10 +32,8 @@ def build_easystack_from_pr(pr, event_info):
     log("build_job_script '%s'" % build_job_script)
     submit_command = buildenv.get('submit_command')
     log("submit_command '%s'" % submit_command)
-
-    # [common_job_params]
-    common_job_params = config.get_section('common_job_params')
-    slurm_params = common_job_params.get('slurm_params')
+    slurm_params = buildenv.get('slurm_params')
+    log("slurm_params '%s'" % slurm_params)
 
     # [architecturetargets]
     arch_target_map = json.loads(config.get_section('architecturetargets').get('arch_target_map'))

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -132,7 +132,7 @@ def build_easystack_from_pr(pr, event_info):
         #log("Applied patch!\nStdout %s\nStderr: %s" % (patched.stdout,patched.stderr))
 
         fetch_cmd = 'git fetch origin pull/%s/head:pr%s' % (pr.number,pr.number)
-        log("Fetch pull request %s into local branch %s by running cmd '%s'" % (pr.number,'pr'+pr.number,fetch_cmd)
+        log("Fetch pull request %s into local branch %s by running cmd '%s'" % (pr.number,'pr'+pr.number,fetch_cmd))
         fetched = subprocess.run(fetch_cmd,
                                  cwd=arch_job_dir,
                                  shell=True,
@@ -141,7 +141,7 @@ def build_easystack_from_pr(pr, event_info):
         log("Fetched PR %s!\nStdout %s\nStderr: %s" % (pr.number,fetched.stdout,fetched.stderr))
 
         checkout_cmd = 'git checkout pr%s' % pr.number
-        log("Checkout branch %s that contains pull request %s by running cmd '%s'" % ('pr'+pr.number,pr.number,checkout_cmd)
+        log("Checkout branch %s that contains pull request %s by running cmd '%s'" % ('pr'+pr.number,pr.number,checkout_cmd))
         checkedout = subprocess.run(checkout_cmd,
                                     cwd=arch_job_dir,
                                     shell=True,

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -113,41 +113,41 @@ def build_easystack_from_pr(pr, event_info):
                                      stderr=subprocess.PIPE)
         log("Cloned repo!\nStdout %s\nStderr: %s" % (cloned_repo.stdout,cloned_repo.stderr))
 
-        #curl_cmd = 'curl -L https://github.com/%s/pull/%s.patch > %s.patch' % (repo_name,pr.number,pr.number)
-        #log("Obtain patch by running '%s' in directory '%s'" % (curl_cmd,arch_job_dir))
-        #got_patch = subprocess.run(curl_cmd,
-        #                           cwd=arch_job_dir,
-        #                           shell=True,
-        #                           stdout=subprocess.PIPE,
-        #                           stderr=subprocess.PIPE)
-        #log("Got patch!\nStdout %s\nStderr: %s" % (got_patch.stdout,got_patch.stderr))
+        curl_cmd = 'curl -L https://github.com/%s/pull/%s.patch > %s.patch' % (repo_name,pr.number,pr.number)
+        log("Obtain patch by running '%s' in directory '%s'" % (curl_cmd,arch_job_dir))
+        got_patch = subprocess.run(curl_cmd,
+                                   cwd=arch_job_dir,
+                                   shell=True,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        log("Got patch!\nStdout %s\nStderr: %s" % (got_patch.stdout,got_patch.stderr))
 
-        #git_am_cmd = 'git am %s.patch' % pr.number
-        #log("Apply patch by running '%s' in directory '%s'" % (git_am_cmd,arch_job_dir))
-        #patched = subprocess.run(git_am_cmd,
-        #                         cwd=arch_job_dir,
-        #                         shell=True,
-        #                         stdout=subprocess.PIPE,
-        #                         stderr=subprocess.PIPE)
-        #log("Applied patch!\nStdout %s\nStderr: %s" % (patched.stdout,patched.stderr))
-
-        fetch_cmd = 'git fetch origin pull/%s/head:pr%s' % (pr.number,pr.number)
-        log("Fetch pull request %s into local branch %s by running cmd '%s'" % (pr.number,'pr'+pr.number,fetch_cmd))
-        fetched = subprocess.run(fetch_cmd,
+        git_am_cmd = 'git am %s.patch' % pr.number
+        log("Apply patch by running '%s' in directory '%s'" % (git_am_cmd,arch_job_dir))
+        patched = subprocess.run(git_am_cmd,
                                  cwd=arch_job_dir,
                                  shell=True,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
-        log("Fetched PR %s!\nStdout %s\nStderr: %s" % (pr.number,fetched.stdout,fetched.stderr))
+        log("Applied patch!\nStdout %s\nStderr: %s" % (patched.stdout,patched.stderr))
 
-        checkout_cmd = 'git checkout pr%s' % pr.number
-        log("Checkout branch %s that contains pull request %s by running cmd '%s'" % ('pr'+pr.number,pr.number,checkout_cmd))
-        checkedout = subprocess.run(checkout_cmd,
-                                    cwd=arch_job_dir,
-                                    shell=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
-        log("Checked out PR %s!\nStdout %s\nStderr: %s" % (pr.number,checkedout.stdout,checkedout.stderr))
+        #fetch_cmd = 'git fetch origin pull/%s/head:pr%s' % (pr.number,pr.number)
+        #log("Fetch pull request %s into local branch %s by running cmd '%s'" % (pr.number,'pr'+str(pr.number),fetch_cmd))
+        #fetched = subprocess.run(fetch_cmd,
+        #                         cwd=arch_job_dir,
+        #                         shell=True,
+        #                         stdout=subprocess.PIPE,
+        #                         stderr=subprocess.PIPE)
+        #log("Fetched PR %s!\nStdout %s\nStderr: %s" % (pr.number,fetched.stdout,fetched.stderr))
+
+        #checkout_cmd = 'git checkout pr%s' % pr.number
+        #log("Checkout branch %s that contains pull request %s by running cmd '%s'" % ('pr'+str(pr.number),pr.number,checkout_cmd))
+        #checkedout = subprocess.run(checkout_cmd,
+        #                            cwd=arch_job_dir,
+        #                            shell=True,
+        #                            stdout=subprocess.PIPE,
+        #                            stderr=subprocess.PIPE)
+        #log("Checked out PR %s!\nStdout %s\nStderr: %s" % (pr.number,checkedout.stdout,checkedout.stderr))
 
         # check if we need to apply local customizations:
         #   is cvmfs_customizations defined? yes, apply it

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -50,6 +50,8 @@ def build_easystack_from_pr(pr, event_info):
     log("http_proxy '%s'" % http_proxy)
     https_proxy = buildenv.get('https_proxy') or ''
     log("https_proxy '%s'" % https_proxy)
+    load_modules = buildenv.get('load_modules') or ''
+    log("load_modules '%s'" % load_modules)
 
 
     # [architecturetargets]
@@ -190,6 +192,8 @@ def build_easystack_from_pr(pr, event_info):
             command_line += ' --http-proxy ' + http_proxy
         if https_proxy:
             command_line += ' --https-proxy ' + https_proxy
+        if load_modules:
+            command_line += ' --load-modules ' + load_modules
 
         # TODO the handling of generic targets requires a bit knowledge about
         #      the internals of building the software layer, maybe ok for now,

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -134,16 +134,17 @@ def build_easystack_from_pr(pr, event_info):
         #   parse job id & add it to array of submitted jobs PLUS create a symlink from main pr_<ID> dir to job dir (job[0])
         job_id = submitted.stdout.split()[3].decode("UTF-8")
         submitted_jobs.append(job_id)
-        job_comment += '|%s|submitted|%s|%s|\n' % (job_id,arch_target,job[0])
+        symlink = os.path.join(jobs_base_dir, ym, pr_id, job_id)
+        job_comment += '|%s|submitted|n/a|%s|%s|\n' % (job_id,arch_target,symlink)
         log("jobs_base_dir: %s, ym: %s, pr_id: %s, job_id: %s" % (jobs_base_dir,ym,pr_id,job_id))
-        os.symlink(job[0], os.path.join(jobs_base_dir, ym, pr_id, job_id))
+        os.symlink(job[0], symlink)
         log("Submit command executed!\nStdout: %s\nStderr: %s" % (submitted.stdout, submitted.stderr))
 
     # report submitted jobs (incl architecture, ...)
     comment = 'Submitted %d job(s) on %s\n' % (len(submitted_jobs),app_name)
     if len(submitted_jobs) > 0:
-        comment += '|job id|job status|os/architecture|job directory|\n'
-        comment += '|------|----------|----------------|------------------------------|\n'
+        comment += '|job id|job status|end time|os/architecture|job directory|\n'
+        comment += '|------|----------|--------|----------------|------------------------------|\n'
     # repo_name = pr.base.repo.full_name # already set above
     repo = gh.get_repo(repo_name)
     pull_request = repo.get_pull(pr.number)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -134,13 +134,13 @@ def build_easystack_from_pr(pr, event_info):
         #   parse job id & add it to array of submitted jobs PLUS create a symlink from main pr_<ID> dir to job dir (job[0])
         job_id = submitted.stdout.split()[3].decode("UTF-8")
         submitted_jobs.append(job_id)
-        job_comment += 'OS/ARCH=%s JOBID=%d JOBDIR=%s\n' % (arch_target,job_id,job[0])
+        job_comment += '* OS/ARCH=%s\n* JOBID=%s\n* JOBDIR=%s\n' % (arch_target,job_id,job[0])
         log("jobs_base_dir: %s, ym: %s, pr_id: %s, job_id: %s" % (jobs_base_dir,ym,pr_id,job_id))
         os.symlink(job[0], os.path.join(jobs_base_dir, ym, pr_id, job_id))
         log("Submit command executed!\nStdout: %s\nStderr: %s" % (submitted.stdout, submitted.stderr))
 
-    # TODO: report submitted jobs (incl architecture, ...)
-    comment = 'Submitted %d job(s) on "%s"\n' % len(submitted_jobs,app_name)
+    # report submitted jobs (incl architecture, ...)
+    comment = 'Submitted %d job(s) on %s\n' % (len(submitted_jobs),app_name)
     # repo_name = pr.base.repo.full_name # already set above
     repo = gh.get_repo(repo_name)
     pull_request = repo.get_pull(pr.number)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -39,7 +39,9 @@ def build_easystack_from_pr(pr, event_info):
         cvmfs_customizations_str = buildenv.get('cvmfs_customizations')
         log("cvmfs_customizations '%s'" % cvmfs_customizations_str)
 
-        cvmfs_customizations = json.loads(cvmfs_customizations_str)
+        if cvmfs_customizations_str != None:
+            cvmfs_customizations = json.loads(cvmfs_customizations_str)
+
         log("cvmfs_customizations '%s'" % json.dumps(cvmfs_customizations))
     except json.decoder.JSONDecodeError as e:
         print(e)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -92,18 +92,12 @@ def build_easystack_from_pr(pr, event_info):
         # download pull request to arch_job_dir
         #  - PyGitHub doesn't seem capable of doing that (easily);
         #  - for now, keep it simple and just execute the commands (anywhere) (note 'git clone' requires that destination is an empty directory)
-        #  NOTE, patching method seems to fail sometimes, using a different method
         #    * patching method
         #      git clone https://github.com/REPO_NAME arch_job_dir
         #      git checkout BRANCH (is stored as ref for base record in PR)
         #      curl -L https://github.com/REPO_NAME/pull/PR_NUMBER.patch > arch_job_dir/PR_NUMBER.patch
         #    (execute the next one in arch_job_dir)
         #      git am PR_NUMBER.patch
-        #    * fetching method
-        #      git clone https://github.com/REPO_NAME arch_job_dir
-        #      cd arch_job_dir
-        #      git fetch origin pull/PR_NUMBER/head:prPR_NUMBER
-        #      git checkout prPR_NUMBER
         #
         #  - REPO_NAME is repo_name
         #  - PR_NUMBER is pr.number
@@ -149,24 +143,6 @@ def build_easystack_from_pr(pr, event_info):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         log("Applied patch!\nStdout %s\nStderr: %s" % (patched.stdout,patched.stderr))
-
-        #fetch_cmd = 'git fetch origin pull/%s/head:pr%s' % (pr.number,pr.number)
-        #log("Fetch pull request %s into local branch %s by running cmd '%s'" % (pr.number,'pr'+str(pr.number),fetch_cmd))
-        #fetched = subprocess.run(fetch_cmd,
-        #                         cwd=arch_job_dir,
-        #                         shell=True,
-        #                         stdout=subprocess.PIPE,
-        #                         stderr=subprocess.PIPE)
-        #log("Fetched PR %s!\nStdout %s\nStderr: %s" % (pr.number,fetched.stdout,fetched.stderr))
-
-        #checkout_cmd = 'git checkout pr%s' % pr.number
-        #log("Checkout branch %s that contains pull request %s by running cmd '%s'" % ('pr'+str(pr.number),pr.number,checkout_cmd))
-        #checkedout = subprocess.run(checkout_cmd,
-        #                            cwd=arch_job_dir,
-        #                            shell=True,
-        #                            stdout=subprocess.PIPE,
-        #                            stderr=subprocess.PIPE)
-        #log("Checked out PR %s!\nStdout %s\nStderr: %s" % (pr.number,checkedout.stdout,checkedout.stderr))
 
         # check if we need to apply local customizations:
         #   is cvmfs_customizations defined? yes, apply it
@@ -256,7 +232,6 @@ def build_easystack_from_pr(pr, event_info):
         dt = datetime.now(timezone.utc)
         job_comment += '|%s|submitted|job waits for release by job manager|' % (dt.strftime("%b %d %X %Z %Y"))
 
-        # repo_name = pr.base.repo.full_name # already set above
         repo = gh.get_repo(repo_name)
         pull_request = repo.get_pull(pr.number)
         pull_request.create_issue_comment(job_comment)

--- a/tools/args.py
+++ b/tools/args.py
@@ -34,4 +34,9 @@ def parse():
         help="loop behaviour: i<0 - indefinite, i==0 - don't run, i>0: run i iterations (default -1)",
     )
 
+    parser.add_argument(
+        "-j", "--jobs",
+        help="limits the processing to a specific job id or list of comma-separated list of job ids",
+    )
+
     return parser.parse_args()

--- a/tools/args.py
+++ b/tools/args.py
@@ -28,4 +28,10 @@ def parse():
         "-p", "--port", default=3000,
         help="listen on a specific port for events (default 3000)",
     )
+
+    parser.add_argument(
+        "-i", "--max-monitor-iterations", default=-1,
+        help="loop behaviour: i<0 - indefinite, i==0 - don't run, i>0: run i iterations (default -1)",
+    )
+
     return parser.parse_args()

--- a/tools/args.py
+++ b/tools/args.py
@@ -30,7 +30,7 @@ def parse():
     )
 
     parser.add_argument(
-        "-i", "--max-monitor-iterations", default=-1,
+        "-i", "--max-manager-iterations", default=-1,
         help="loop behaviour: i<0 - indefinite, i==0 - don't run, i>0: run i iterations (default -1)",
     )
 


### PR DESCRIPTION
This is a larger pull request. Among a few smaller changes (e.g., adding ability to specify port on which the bot listens, makes PR #22 obsolete, sorry) it adds functionality to monitor the status of jobs, then checks the result of finished jobs and updates the PR accordingly.

The monitoring implements option 1 in #12. This is a bit inelegant -- it only uses `squeue` because `sacct` wasn't available on the CitC cluster on AWS and uses `pandas` to read in the output from `squeue` which might be overkill. An improvement would be to enable the bot monitoring jobs even after it has crashed (see #23). A future version of the bot could have different implementations for monitoring the jobs and then select the best one based on what is available on a cluster (`sacct` or `squeue`). Also, one might have a look into [PySlurm/pyslurm](https://github.com/PySlurm/pyslurm) to verify if this monitoring can be done more elegantly.

The result of a finished job is checked (existence of slurm output file, existence of tar.gz file, existence of certain pattern in slurm output file). This is relatively clean.

Then the bot adds a comment to the PR with information about the result of the build job. This implements #13.

This PR also addresses #17.