### PR TITLE
(WIP) Adding tools to help debugging build failures

### DIFF
--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -188,9 +188,9 @@ class EESSIBotSoftwareLayerJobManager:
                     # NOTE adjust search string if format changed by event
                     #        handler (separate process running
                     #        eessi_bot_software_layer.py)
-                    cms = '^Job `%s` on `%s`.*' % (
-                            new_job['jobid'],
-                            config.get_section('github').get('app_name'))
+                    cms = '.*submitted.*job id `%s`.*' % new_job['jobid']
+#                            new_job['jobid'],
+#                            config.get_section('github').get('app_name'))
 
                     comment_match = re.search(cms, comment.body)
 
@@ -273,9 +273,10 @@ class EESSIBotSoftwareLayerJobManager:
                 # NOTE adjust search string if format changed by event
                 #        handler (separate process running
                 #        eessi_bot_software_layer.py)
-                cms = '^Job `%s` on `%s`.*' % (
-                        finished_job['jobid'],
-                        config.get_section('github').get('app_name'))
+                cms = '.*submitted.*job id `%s`.*' % finished_job['jobid']
+#                cms = '^Job `%s` on `%s`.*' % (
+#                        finished_job['jobid'],
+#                        config.get_section('github').get('app_name'))
 
                 comment_match = re.search(cms, comment.body)
 

--- a/inspect_pr.py
+++ b/inspect_pr.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import configparser
+import json
+import glob
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+from connections import github
+from datetime import datetime, timezone
+from tools import args, config
+
+from pyghee.utils import create_file
+
+from git import Git, Repo
+import requests
+from typing import Tuple
+
+# parse command-line args
+opts = args.parse()
+
+repo_name = None
+if opts.repository_name is not None:
+    repo_name = opts.repository_name
+else:
+    print("need a full repository name")
+    quit()
+
+print("repository name: %s" % repo_name)
+
+pr_number = None
+if opts.pr_number is not None:
+    pr_number = opts.pr_number
+else:
+    print("need a pull request number")
+    quit()
+
+print("pull request number: %s" % pr_number)
+
+config.read_file("app.cfg")
+github.connect()
+gh = github.get_instance()
+repo = gh.get_repo(repo_name)
+pr   = repo.get_pull(int(pr_number))
+base_ref = pr.base.ref
+
+print("base_ref = '%s'" % base_ref)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ PyGithub
 Waitress
 cryptography
 PyGHee>=0.0.2
+GitPython
+Requests

--- a/resubmit.py
+++ b/resubmit.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+#
+# script to resubmit a job with or without changes applied
+#   only locally to a PR's content; still updating the
+#   original PR comment and enabling the job manager to
+#   pick the job up (including releasing it)
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+## resubmit.py [PATH_TO_ORG_JOB [RERUN_DIR]]
+## * if PATH_TO_ORG_JOB not given -> run from current directory
+## * if RERUN_DIR (relative to PATH_TO_ORG_JOB) not given, create it
+## * in RERUN_DIR create symlinks for all files not included in
+##   the dir, that is all to all PR files in PATH_TO_ORG_DIR
+## * resubmit job with same sbatch parameters as org
+##   (/usr/bin/sbatch --hold --get-user-env --account=nn9992k \
+##               --time=3-00:00:00 --nodes=1 \
+##               --ntasks-per-node=12 --mem=60G \
+##               --gres=localscratch:120G --partition normal \
+##               --exclude=c1-[1-56],c2-[1-56],c3-[1-28],c5-[1-60] \
+##       /cluster/projects/nn9992k/pilot.nessi/eessi-bot-software-layer/scripts/eessi-bot-build.slurm \
+##          --tmpdir \$LOCALSCRATCH/EESSI \
+##          --http-proxy http://proxy.saga:3128/ \
+##          --https-proxy http://proxy.saga:3128/)
+## * create _bot_jobID.metadata file
+## * ensure symlink structures are maintained such that the job
+##   manager can pick up the job as if it was submitted by the
+##   event handler
+## * update PR comment (need to identify comment): 
+##     DATE | resubmitted | comment
+##     new job id, directory; possibly changes (diff) as details
+
+import configparser
+import json
+import glob
+import os
+import re
+import subprocess
+import time
+
+from connections import github
+from datetime import datetime, timezone
+from tools import args, config
+
+from pyghee.utils import create_file, log
+
+# "-o", "--original-job-dir",
+# help="original job directory when resubmitting",
+# "-r", "--rerun-job-dir",
+# help="directory relative to original job directory which contains information to rerun job",
+
+def mkdir(path):
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+opts = args.parse()
+
+app_cfg_dir = os.path.dirname(os.path.realpath(__file__))
+app_cfg = os.path.join(app_cfg_dir,'app.cfg')
+print('app.cfg: %s\n' % app_cfg)
+
+config.read_file(app_cfg)
+
+#github.connect()
+
+original_job_dir = os.getcwd()
+if opts.original_job_dir is not None:
+    original_job_dir = opts.original_job_dir
+print("original job dir: '%s'" % original_job_dir)
+
+rerun_job_dir = None
+if opts.rerun_job_dir is not None:
+    rerun_job_dir = os.path.join(original_job_dir,opts.rerun_job_dir)
+else:
+    # determine next dir for resubmission with scheme 'rerun_NUM' where NUM begins with 000
+    run = 0
+    while os.path.exists(os.path.join(original_job_dir, 'rerun_%03d' % run)):
+        run += 1
+    rerun_job_dir = os.path.join(original_job_dir, 'rerun_%03d' % run)
+print("rerun job dir: '%s'" % rerun_job_dir)
+
+# mkdir -p rerun_job_dir
+mkdir(rerun_job_dir)
+
+# determine files that belong to PR but not in rerun_job_dir
+#   and create symlinks to them from rerun_job_dir
+#   also need to handle directories in PR an rerun_job_dir
+#   ignore .git... entries in PR
+#  PR contents: git ls-tree -r HEAD --names-only
+#  rerun_job_dir contents: glob.iglob(rerun_dir)
+
+git_ls_tree_cmd = ' '.join( [
+                      'git',
+                      'ls-tree',
+                      '-r', 'HEAD',
+                      '--name-only' ])
+s = subprocess.Popen([ "git ls-tree -r HEAD --name-only | grep -v '^\.'" ], shell=True, stdout=subprocess.PIPE).stdout
+pr_files = s.read().splitlines()
+rerun_files = glob.iglob(os.path.join(rerun_job_dir,'**'),recursive=True)
+print("FILES IN PR:")
+for s in pr_files:
+    s_str = s.decode("UTF-8")
+    print(s_str)
+    for f in rerun_files:
+        #print('%s -> abspath %s' % (f, os.path.abspath(f)) )
+        if os.path.realpath(rerun_job_dir) != os.path.realpath(os.path.abspath(f)):
+            ff

--- a/resubmit.py
+++ b/resubmit.py
@@ -37,73 +37,394 @@ import json
 import glob
 import os
 import re
+import shutil
 import subprocess
+import sys
 import time
 
 from connections import github
 from datetime import datetime, timezone
 from tools import args, config
 
-from pyghee.utils import create_file, log
+from pyghee.utils import create_file
+
+from git import Git, Repo
+import requests
+from typing import Tuple
 
 # "-o", "--original-job-dir",
 # help="original job directory when resubmitting",
 # "-r", "--rerun-job-dir",
 # help="directory relative to original job directory which contains information to rerun job",
 
+############### BEGIN OF DEFINITIONS #####################################
+
 def mkdir(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
+# determine last jobid (in most cases there will be just one
+#     jobid per directory)
+#   - possible sources: _bot_job<JOBID>.metadata file(s),
+#                       slurm-<JOBID>.out file(s)
+def determine_last_jobid(directory: str = None) -> int:
+    if directory is None:
+        directory = os.getcwd()
+    # TODO make sure that directory exists and is accessible
+    # determine list of files (metadata or slurm out)
+    glob_metadata = '_bot_job[0-9]*.metadata'
+    metadata_files = glob.glob(os.path.join(directory, glob_metadata))
+    glob_slurm_out = 'slurm-[0-9]*.out'
+    slurm_out_files = glob.glob(os.path.join(directory, glob_slurm_out))
+    job_ids = [ int(re.sub("(.*_bot_job)|(.metadata)", "", jobid)) for jobid in metadata_files ] + \
+              [ int(re.sub("(.*slurm-)|(.out)", "", jobid)) for jobid in slurm_out_files ]
+    # return based on number of jobs
+    if len(job_ids) > 0:
+        return sorted(job_ids, reverse=True)[0]
+    else:
+        return None
+
+
+# get repo name and PR number from file _bot_job<JOBID>.metadata
+#     the file should be written by the event handler to the working
+#     dir of the job
+def get_pull_request_info(jobid: int, directory: str = None) -> Tuple[str, int]:
+    if directory is None:
+        directory = os.getcwd()
+    # TODO make sure that directory exists and is accessible
+    job_metadata_file = '_bot_job%d.metadata' % jobid
+    job_metadata_path = os.path.join(directory, job_metadata_file)
+    metadata = configparser.ConfigParser()
+    try:
+        metadata.read(job_metadata_path)
+    except Exception as e:
+        print(e)
+        error(f'Unable to read job metadata file {job_metadata_path}!')
+
+    repo_name = None
+    pr_number = None
+    if 'PR' in metadata:
+        metadata_pr = metadata['PR']
+        repo_name = metadata_pr['repo'] or None
+        pr_number = metadata_pr['pr_number'] or None
+
+    return repo_name, pr_number
+
+
+# get arch name, operating system and job params from file _bot_job<JOBID>.metadata
+#     the file should be written by the event handler to the working
+#     dir of the job
+def get_arch_info(jobid: int, directory: str = None) -> Tuple[str, str, str]:
+    if directory is None:
+        directory = os.getcwd()
+    # TODO make sure that directory exists and is accessible
+    job_metadata_file = '_bot_job%d.metadata' % jobid
+    job_metadata_path = os.path.join(directory, job_metadata_file)
+    metadata = configparser.ConfigParser()
+    try:
+        metadata.read(job_metadata_path)
+    except Exception as e:
+        print(e)
+        error(f'Unable to read job metadata file {job_metadata_path}!')
+
+    arch_name = None
+    os_name = None
+    slurm_opt = None
+    if 'ARCH' in metadata:
+        metadata_arch = metadata['ARCH']
+        arch_name = metadata_arch['architecture'] or None
+        os_name   = metadata_arch['os'] or None
+        slurm_opt = metadata_arch['slurm_opt'] or None
+
+    return arch_name, os_name, slurm_opt
+
+
+# download pull request to arch_job_dir
+#  - PyGitHub doesn't seem capable of doing that (easily);
+#  - for now, keep it simple and just execute the commands (anywhere) (note 'git clone' requires that destination is an empty directory)
+#  NOTE, patching method seems to fail sometimes, using a different method
+#    * patching method
+#      git clone https://github.com/REPO_NAME arch_job_dir
+#      curl -L https://github.com/REPO_NAME/pull/PR_NUMBER.patch > arch_job_dir/PR_NUMBER.patch
+#    (execute the next one in arch_job_dir)
+#      git am PR_NUMBER.patch
+#    * fetching method
+#      git clone https://github.com/REPO_NAME arch_job_dir
+#      cd arch_job_dir
+#      git fetch origin pull/PR_NUMBER/head:prPR_NUMBER
+#      git checkout prPR_NUMBER
+#
+#  - REPO_NAME is repo_name
+#  - PR_NUMBER is pr.number
+def obtain_pull_request(work_directory: str,
+                        target_directory: str,
+                        repository_name: str,
+                        pull_request_number: int) -> bool:
+
+    # TODO check if target_directory already exists under work_directory
+    # (1) clone repo
+    repo_url = 'https://github.com/'+repository_name
+    target_path = os.path.join(work_directory, target_directory)
+    cloned_repo = Repo.clone_from(url=repo_url, to_path=target_path)
+    assert cloned_repo.__class__ is Repo
+    print("Cloned repo '%s' into '%s'." % (repo_url, target_path))
+
+    # (2) optain patch for pull request
+    patch_file = pull_request_number + '.patch'
+    patch_url = repo_url + '/pull/' + patch_file
+    patch_target = os.path.join(target_path, patch_file)
+    r = requests.get(patch_url)
+    with open(patch_target, 'w') as p:
+        p.write(r.text)
+    print("Stored patch under '%s'." % patch_target)
+
+    # (3) apply patch
+    git = Git(target_path)
+    status, am_out, am_err = git.am(patch_target, with_extended_output = True)
+    print("Applied patch: status %d, out '%s', err '%s'" % (status, am_out, am_err) )
+
+    return (status == 0)
+
+
+def remove_prefix(path: str, prefix: str) -> str:
+    if path.startswith(prefix):
+        return path[len(prefix):]
+    return path
+
+
+def copy_contents(source_directory: str, target_directory: str) -> bool:
+    #print("source_directory %s" % source_directory)
+    #print("target_directory %s" % target_directory)
+    for root, dirs, files in os.walk(source_directory):
+        path = root.split(os.sep)
+        base = os.path.basename(root)
+        dirname = os.path.dirname(root)
+        #print("SRC: root %s, dir '%s', base '%s'" % (root, dirname, base))
+        rel_target = remove_prefix(root, source_directory).strip('/')
+        todir = os.path.join(target_directory, rel_target).rstrip('/')
+        #print("DST: root %s, dir '%s', todir '%s'" % (target_directory, rel_target, todir))
+        if root != source_directory:
+            #if os.path.islink(root):
+            #    print("%s%s %s (in dir %s)" % ((len(path)-2) * '---', '--L', base, dirname))
+            #if os.path.isfile(root):
+            #    print("%s%s %s (in dir %s)" % ((len(path)-2) * '---', '--F', base, dirname))
+            if os.path.isdir(root):
+                #print("%s%s %s (from dir %s to dir %s)" % ((len(path)-2) * '---', '--D', base, dirname, todir))
+                mkdir(todir)
+            #else:
+            #    print("%s%s %s (in dir %s)" % ((len(path)-2) * '---', '--*', base, dirname))
+        for f in files:
+            src = os.path.join(root,f)
+            if os.path.islink(src):
+                #print("%s%s %s (from dir %s to dir %s)" % ((len(path)-1) * '---', '--L', f, root, todir))
+                linkto = os.readlink(src)
+                linkfrom = os.path.join(todir,f)
+                #print("    symlink from %s to %s" % (linkfrom, linkto))
+                os.symlink(linkto, linkfrom)
+            else:
+                #print("%s%s %s (from dir %s to dir %s)" % ((len(path)-1) * '---', '--f', f, root, todir))
+                shutil.copy(src, todir)
+            
+    return True
+
+############### END OF DEFINITIONS #######################################
+
+print()
+
+# parse command-line args
 opts = args.parse()
 
+# determine location of app config file (app.cfg)
+#   IDEA should we have a command line argument for this one?
+#   for now assumes that the file is in the directory of this script
 app_cfg_dir = os.path.dirname(os.path.realpath(__file__))
 app_cfg = os.path.join(app_cfg_dir,'app.cfg')
-print('app.cfg: %s\n' % app_cfg)
-
+print('app.cfg ........: %s' % app_cfg)
+# read config file
+#   -> should make key parameters available:
+#         private_key, build_job_script, {cvmfs_customizations},
+#         http(s)_proxy, load_modules, {local_tmp}, slurm_params,
+#         submit_command, arch_target_map, job_ids_dir
 config.read_file(app_cfg)
 
+# commented for now as it seemed to take very long to connect
 #github.connect()
 
-original_job_dir = os.getcwd()
+# determine directory of original job (current or given as argument)
+original_job_dir = None
 if opts.original_job_dir is not None:
     original_job_dir = opts.original_job_dir
-print("original job dir: '%s'" % original_job_dir)
-
-rerun_job_dir = None
-if opts.rerun_job_dir is not None:
-    rerun_job_dir = os.path.join(original_job_dir,opts.rerun_job_dir)
 else:
-    # determine next dir for resubmission with scheme 'rerun_NUM' where NUM begins with 000
-    run = 0
-    while os.path.exists(os.path.join(original_job_dir, 'rerun_%03d' % run)):
-        run += 1
-    rerun_job_dir = os.path.join(original_job_dir, 'rerun_%03d' % run)
-print("rerun job dir: '%s'" % rerun_job_dir)
+    original_job_dir = os.getcwd()
+print("original job dir: %s" % original_job_dir)
 
-# mkdir -p rerun_job_dir
-mkdir(rerun_job_dir)
+# prepare directory for job to re-run
+#   Note 1, it always creates a new directory 'rerun_NUM' under
+#           original_job_dir.
+#   Note 2, the directory rerun_job_dir is used as input for possible
+#           changes to the original job. All contents of rerun_job_dir
+#           is simply copied into rerun_NUM.
+# (1) determine rerun_NUM under original_job_dir
+run = 0
+while os.path.exists(os.path.join(original_job_dir, 'rerun_%03d' % run)):
+    run += 1
+rerun_job_dir = os.path.join(original_job_dir, 'rerun_%03d' % run)
+print("rerun job dir ..: %s" % rerun_job_dir)
 
-# determine files that belong to PR but not in rerun_job_dir
-#   and create symlinks to them from rerun_job_dir
-#   also need to handle directories in PR an rerun_job_dir
-#   ignore .git... entries in PR
-#  PR contents: git ls-tree -r HEAD --names-only
-#  rerun_job_dir contents: glob.iglob(rerun_dir)
+# (2) prepare contents of rerun directory
+#   (2a) get repo name and pr number from metadata file
+#   (2b) get original PR, patch and apply patch (same method used by
+#        event handler) + do customizations (cvmfs, ...)
+#   (2c) copy contents from directory that contains changes
+#
+# (2a) get repo name and pr number from metadata file
+org_job_id = determine_last_jobid(original_job_dir)
+print("last job id ....: %d" % org_job_id)
 
-git_ls_tree_cmd = ' '.join( [
-                      'git',
-                      'ls-tree',
-                      '-r', 'HEAD',
-                      '--name-only' ])
-s = subprocess.Popen([ "git ls-tree -r HEAD --name-only | grep -v '^\.'" ], shell=True, stdout=subprocess.PIPE).stdout
-pr_files = s.read().splitlines()
-rerun_files = glob.iglob(os.path.join(rerun_job_dir,'**'),recursive=True)
-print("FILES IN PR:")
-for s in pr_files:
-    s_str = s.decode("UTF-8")
-    print(s_str)
-    for f in rerun_files:
-        #print('%s -> abspath %s' % (f, os.path.abspath(f)) )
-        if os.path.realpath(rerun_job_dir) != os.path.realpath(os.path.abspath(f)):
-            ff
+repo_name, pr_number = get_pull_request_info(org_job_id, original_job_dir)
+
+print("repository name.: %s" % repo_name)
+print("pr number ......: %s" % pr_number)
+
+arch_name, os_name, slurm_opt = get_arch_info(org_job_id, original_job_dir)
+
+print("archictecture ..: %s" % arch_name)
+print("operating system: %s" % os_name)
+print("job params .....: %s" % slurm_opt)
+
+# (2b) get original PR, patch and apply patch (same method used by
+#      event handler) + do customizations (cvmfs, ...)
+if not obtain_pull_request(original_job_dir,
+                           rerun_job_dir,
+                           repo_name,
+                           pr_number):
+    print("failed to obtain pull request")
+    sys.exit(-2)
+# TODO do customizations
+
+# (2c) copy contents from directory that contains changes
+if opts.modified_job_dir is not None:
+    copy_contents(opts.modified_job_dir, rerun_job_dir)
+
+#sys.exit()
+
+# (3) submit job, create metadata file, create symlink, update PR comment
+# prepare metadata file --> after submission, just rename it
+# create _bot_job<jobid>.metadata file in submission directory
+bot_jobfile = configparser.ConfigParser()
+bot_jobfile['PR'] = { 'repo' : repo_name, 'pr_number' : pr_number }
+bot_jobfile['ARCH'] = { 'architecture' : arch_name, 'os' : os_name, 'slurm_opt' : slurm_opt }
+bot_jobfile_path = os.path.join(rerun_job_dir, '_bot_job%s.metadata' % 'TEMP')
+with open(bot_jobfile_path, 'w') as bjf:
+    bot_jobfile.write(bjf)
+
+# find PR comment (old job id, appname from app.cfg) and update it
+#   'date | resubmitted | jobid + directory'
+#     --> update method in job manager to find comment
+# next line requires access to app.cfg which provides app_id,
+#      installation_id and private_key
+# - access to app.cfg requires that config app.cfg is read with
+#      'config.read_file("app.cfg")'
+#      should be done early in this script
+gh = github.get_instance()
+repo = gh.get_repo(repo_name)
+pr   = repo.get_pull(int(pr_number))
+base_ref = pr.base.ref
+
+comments = pr.get_issue_comments()
+comment_id = ''
+for comment in comments:
+    # NOTE adjust search string if format changed by event
+    #        handler (separate process running
+    #        eessi_bot_software_layer.py)
+    cms = '.*submitted.*job id `%s`.*' % org_job_id
+
+    comment_match = re.search(cms, comment.body)
+
+    if comment_match:
+        print("found comment with id %s" % comment.id)
+        comment_id = comment.id
+        break
+
+# prepare command for submission
+# (first) obtain some config values
+# [buildenv]
+buildenv = config.get_section('buildenv')
+jobs_base_dir = buildenv.get('jobs_base_dir')
+print("jobs_base_dir '%s'" % jobs_base_dir)
+local_tmp = buildenv.get('local_tmp')
+print("local_tmp '%s'" % local_tmp)
+build_job_script = buildenv.get('build_job_script')
+print("build_job_script '%s'" % build_job_script)
+submit_command = buildenv.get('submit_command')
+print("submit_command '%s'" % submit_command)
+slurm_params = buildenv.get('slurm_params')
+print("slurm_params '%s'" % slurm_params)
+http_proxy = buildenv.get('http_proxy') or ''
+print("http_proxy '%s'" % http_proxy)
+https_proxy = buildenv.get('https_proxy') or ''
+print("https_proxy '%s'" % https_proxy)
+load_modules = buildenv.get('load_modules') or ''
+print("load_modules '%s'" % load_modules)
+
+command_line = ' '.join([
+    submit_command, # app.cfg
+    slurm_params, # app.cfg
+    slurm_opt, # read from _bot_jobJOBID.metadata of original job
+    build_job_script, # app.cfg
+    '--tmpdir', local_tmp, # app.cfg
+])
+if http_proxy:
+    command_line += ' --http-proxy ' + http_proxy
+if https_proxy:
+    command_line += ' --https-proxy ' + https_proxy
+if load_modules:
+    command_line += ' --load-modules ' + load_modules
+
+# TODO the handling of generic targets requires a bit knowledge about
+#      the internals of building the software layer, maybe ok for now,
+#      but it might be good to think about an alternative
+# if target contains generic, add ' --generic' to command line
+if "generic" in arch_name:
+    command_line += ' --generic'
+
+print("Submit job for target '%s' with '%s' from directory '%s'" % (arch_name, command_line, rerun_job_dir))
+
+submitted = subprocess.run(
+    command_line,
+    shell=True,
+    cwd=rerun_job_dir,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE)
+
+# sbatch output is 'Submitted batch job JOBID'
+#   parse job id & add it to array of submitted jobs PLUS create a symlink from main pr_<ID> dir to job dir (job[0])
+job_id = submitted.stdout.split()[3].decode("UTF-8")
+
+# rename job metadata file
+new_metadata_path = bot_jobfile_path.replace('TEMP', job_id, 1)
+os.rename(bot_jobfile_path, new_metadata_path)
+
+# print sbatch status
+print("sbatch out: %s" % submitted.stdout.decode("UTF-8"))
+print("sbatch err: %s" % submitted.stderr.decode("UTF-8"))
+
+# create symlink from jobs_base_dir/YYYY.MM/pr_PR_NUMBER to
+#   rerun_job_dir
+job_mgr = config.get_section('job_manager')
+job_ids_dir = job_mgr.get('job_ids_dir')
+ym = datetime.today().strftime('%Y.%m')
+pr_id = 'pr_%s' % pr.number
+symlink = os.path.join(jobs_base_dir, ym, pr_id, job_id)
+os.symlink(rerun_job_dir, symlink)
+
+# update comment
+if int(comment_id) > 0:
+    print("updating comment with id %s" % comment_id)
+    issue_comment = pr.get_issue_comment(int(comment_id))
+    original_body = issue_comment.body
+    dt = datetime.now(timezone.utc)
+    update = '\n|%s|resubmitted|job id `%s`, dir `%s` awaits release by job manager|' % (dt.strftime("%b %d %X %Z %Y"), job_id, symlink)
+    issue_comment.edit(original_body + update)
+else:
+    print("apparently no comment (%s) to update" % comment_id)

--- a/scripts/eessi-bot-build.slurm
+++ b/scripts/eessi-bot-build.slurm
@@ -127,6 +127,28 @@ else
   echo "eessi-bot-build.slurm: no modules to be loaded"
 fi
 
+source init/minimal_eessi_env  # for $EESSI_PILOT_VERSION and $EESSI_OS_TYPE
+
+software_subdir=
+for i in {1..9};
+do
+  echo "attempt $i to determine software_subdir"
+  raw_output=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1)
+  echo "raw output of eessi_software_subdir.py: '$raw_output'"
+  software_subdir=$(echo $raw_output | tail -1 | sed 's/.* //g')
+  echo "software_subdir: '$software_subdir'"
+  # check if software_subdir has the format:
+  #   CPU_FAMILY/ARCH_IDENTIFIER
+  if [[ $software_subdir == *"/"* ]]; then
+    echo "software_subdir seems well formatted"
+    break
+  else
+    n=$((1<<$i))
+    echo "sleep $n secs (using exponential backoff)"
+    sleep $n
+  fi
+done
+
 # run standard EESSI software-layer install script
 #   in compat layer environment inside build container
 ./build_container.sh run ${eessi_tmpdir} \
@@ -135,12 +157,6 @@ fi
 # create tarball for the above build and place it in some specific
 #   directory on shared disk (just in main directory of job)
 #   see https://github.com/EESSI/eessi-bot-software-layer/issues/7
-
-source init/minimal_eessi_env  # for $EESSI_PILOT_VERSION and $EESSI_OS_TYPE
-
-echo "raw output of eessi_software_subdir.py: '$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1)'"
-software_subdir=$(./build_container.sh run ${eessi_tmpdir} python3 /eessi_bot_job/eessi_software_subdir.py ${generic_opt} 2>&1 | tail -1 | sed 's/.* //g')
-echo "software_subdir: '$software_subdir'"
 
 timestamp=$(date +%s)
 

--- a/tools/args.py
+++ b/tools/args.py
@@ -39,4 +39,24 @@ def parse():
         help="limits the processing to a specific job id or list of comma-separated list of job ids",
     )
 
+    parser.add_argument(
+        "-o", "--original-job-dir",
+        help="original job directory when resubmitting",
+    )
+
+    parser.add_argument(
+        "-m", "--modified-job-dir",
+        help="directory containing modifications to the original job",
+    )
+
+    parser.add_argument(
+        "-n", "--pr-number",
+        help="number of the pull request",
+    )
+
+    parser.add_argument(
+        "-r", "--repository-name",
+        help="name of the repository including username, e.g, USER/repository",
+    )
+
     return parser.parse_args()


### PR DESCRIPTION
This PR addresses issue #29. It adds two tools which help in debugging why a software package cannot be built:

- `resubmit.py` takes a previous job (working directory) and optionally changes to that job (another directory whose files are copied on top of a freshly obtained PR - the contents of the original job). It creates a new job directory, submits the job and updates the comment corresponding to the original job of the PR. Some minor tweaks on the formatting of PR comments were necessary to make this happen.
- `inspect_pr.py` takes the full name of a repository and a PR number and prints some information about the PR. Currently, this shows very limited information (just the `base.repo.ref`), but could be easily extended. While trivial this tool may be useful to show what information the bot can obtain given a specific repository and PR number.

While functional (it's been used extensively to investigate build issues), this PR is flagged _Work-In-Progress_ because it will benefit from resolving the following issues first (first merging this PR may make some of those issues more complex to resolve):
- #32
- #39
- #42
- #44 
