### PR TITLE
working implementation of 'deploy' step

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,46 @@ The above command `pip3 install --user -r requirements.txt` installs the latest 
 export PYTHONPATH=SOME_PATH/PyGHee:$PYTHONPATH
 ```
 
+### <a name="step4.2"></a>Step 4.2: Installing tools to access S3 bucket
+
+The script `scripts/eessi-upload-to-staging` uploads a tarball and an associated metadata file to an S3 bucket. It needs two tools for this, `aws` to actually upload the files and `jq` to create the metadata file. This section describes how these tools are installed and configured on the `bot machine`.
+
+Create a new directory, say `BOT_ROOT/tools` and change into the directory.
+
+For installing the AWS Command Line Interface, including the tool `aws`,
+please follow the instructions at the
+[AWS Command Line Interface guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+
+Add the directory that contains `aws` to the `PATH` environment variable.
+Make sure that the `PATH` is set correctly for newly spawned shells, e.g.,
+it should be exported in files such as `$HOME/.bash_profile`.
+
+Verify that `aws` executes by running `aws --version`. Then, run
+`aws configure` to set credentials for accessing the S3 bucket.
+See [New configuration quick setup](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html)
+for detailed setup instructions. If you are using a non AWS S3 bucket
+you will likely only have to provide the `Access Key ID` and the
+`Secret Access Key`.
+
+Next, install the tool `jq` into the same directory into which
+`aws` was installed in. First, run `cd $(dirname $(which aws))`.
+Then, download `jq` from `https://github.com/stedolan/jq/releases`
+by running, for example,
+```
+curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq-linux64
+```
+You may check if there are newer releases and choose a different
+package depending on your operating system. Update the permissions
+of the downloaded tool (`jq-linux64` for the above `curl` example)
+with
+```
+chmod +x jq-linux64
+```
+Finally, create a symbolic link for `jq` by running
+```
+ln -s jq-linux64 jq
+```
+
 ## <a name="step5"></a>Step 5: Configuring the EESSI bot on the `bot machine`
 
 For the event handler, you need to set up two environment variables: `GITHUB_TOKEN` ([Step 5.1](#step5.1)) and `GITHUB_APP_SECRET_TOKEN` ([Step 5.2](#step5.2)). For both the event handler and the job manager you need a private key ([Step 5.3](#step5.3)).

--- a/README.md
+++ b/README.md
@@ -307,6 +307,41 @@ submit_command = /usr/bin/sbatch
 ```
 This is the full path to the Slurm command used for submitting batch jobs. You may want to verify if `sbatch` is provided at that path or determine its actual location (`which sbatch`).
 
+### Section `[deploycfg]`
+The section `[deploycfg]` defines settings for uploading built artefacts (tarballs) to an S3 bucket.
+```
+upload_to_s3_script = PATH_TO_EESSI_BOT/scripts/eessi-upload-to-staging
+```
+Provides the location for the script used for uploading built software packages to an S3 bucket.
+
+```
+endpoint_url = URL_TO_S3_SERVER
+```
+Provides an endpoint (URL) to a server hosting an S3 bucket. The server could be hosted by a public Cloud provider or running in a private environment, for example, using Minio. The bot uploads tarballs to the bucket which will be periodically scanned by the ingestion procedure at the Stratum 0 server.
+
+```
+bucket_name = eessi-staging
+```
+Name of the bucket used for uploading of tarballs. The bucket must be available on the default server (`https://${bucket_name}.s3.amazonaws.com`) or the one provided via `endpoint_url`.
+
+```
+upload_policy = once
+```
+The `upload_policy` defines what policy is used for uploading built artefacts to an S3 bucket.
+|:--------|:--------------------------------|
+|Value|Policy|
+|`all`|Upload all artefacts (mulitple uploads of the same artefact possible).|
+|`latest`|For each build target (prefix in tarball name `eessi-VERSION-{software,init,compat}-OS-ARCH)` only upload the latest built artefact.|
+|`once`|Only once upload any built artefact for the build target.|
+|`none`|Do not upload any built artefacts.|
+
+```
+deploy_permission = GH_ACCOUNT_1 GH_ACCOUNT_2 ...
+```
+The option `deploy_permission` defines which GitHub accounts can trigger the
+deployment procedure. The value can be empty (any GH account can trigger the
+deployment) or a space delimited list of GH accounts.
+
 ### Section `[architecturetargets]`
 The section `[architecturetargets]` defines for which targets (OS/SUBDIR), e.g., `linux/amd/zen2` the EESSI bot should submit jobs and what additional `sbatch` parameters will be used for requesting a compute node with the CPU microarchitecture needed to build the software stack.
 ```

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -68,6 +68,39 @@ slurm_params = --hold
 submit_command = /usr/bin/sbatch
 
 
+[deploycfg]
+# script for uploading built software packages to S3 bucket
+upload_to_s3_script = PATH_TO_EESSI_BOT/scripts/eessi-upload-to-staging
+
+# URL to S3/minio bucket
+#   if attribute is set, bucket_base will be constructed as follows
+#     bucket_base=${endpoint_url}/${bucket_name}
+#   otherwise, bucket_base will be constructed as follows
+#     bucket_base=https://${bucket_name}.s3.amazonaws.com
+# - The former variant is used for non AWS S3 services, eg, minio, or when
+#   the bucket name is not provided in the hostname (see latter case).
+# - The latter variant is used for AWS S3 services.
+endpoint_url = URL_TO_S3_SERVER
+
+# bucket name
+bucket_name = eessi-staging
+
+# upload policy: defines what policy is used for uploading built artefacts
+#                to an S3 bucket
+# 'all' ..: upload all artefacts (mulitple uploads of the same artefact possible)
+# 'latest': for each build target (eessi-VERSION-{software,init,compat}-OS-ARCH)
+#           only upload the latest built artefact
+# 'once'  : only once upload any built artefact for the build target
+# 'none'  : do not upload any built artefacts
+upload_policy = once
+
+# which GH account has the permission to trigger the deployment (by setting
+# the label 'bot:deploy' (apparently this cannot be restricted on GitHub)
+# if value is left/empty everyone can trigger the deployment
+# value can be a space delimited list of GH accounts
+deploy_permission = trz42
+
+
 [architecturetargets]
 # defines both for which architectures the bot will build
 #   and what submission parameters shall be used

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -19,6 +19,7 @@ import json
 from connections import github
 from tools import args, config
 from tasks.build import submit_build_jobs
+from tasks.deploy import deploy_built_artefacts
 
 from pyghee.lib import PyGHee, create_app, read_event_from_json
 from pyghee.utils import log
@@ -61,6 +62,9 @@ class EESSIBotSoftwareLayer(PyGHee):
         if label == "bot:build":
             # run function to build software stack
             submit_build_jobs(pr, event_info)
+        elif label == "bot:deploy":
+            # run function to deploy built artefacts
+            deploy_built_artefacts(pr, event_info)
         else:
             log("handle_pull_request_labeled_event: no handler for label '%s'" % label)
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -195,9 +195,7 @@ class EESSIBotSoftwareLayerJobManager:
                     # NOTE adjust search string if format changed by event
                     #        handler (separate process running
                     #        eessi_bot_event_handler.py)
-                    cms = '^Job `%s` on `%s`.*' % (
-                            new_job['jobid'],
-                            config.get_section('github').get('app_name'))
+                    cms = f".*submitted.*job id `{new_job['jobid']}`.*"
 
                     comment_match = re.search(cms, comment.body)
 
@@ -280,9 +278,7 @@ class EESSIBotSoftwareLayerJobManager:
                 # NOTE adjust search string if format changed by event
                 #        handler (separate process running
                 #        eessi_bot_event_handler.py)
-                cms = '^Job `%s` on `%s`.*' % (
-                        finished_job['jobid'],
-                        config.get_section('github').get('app_name'))
+                cms = f".*submitted.*job id `{finished_job['jobid']}`.*"
 
                 comment_match = re.search(cms, comment.body)
 

--- a/scripts/eessi-upload-to-staging
+++ b/scripts/eessi-upload-to-staging
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Bob Droege (@bedroge)
+# author: Terje Kvernes (@terjekv)
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+
+function upload_to_staging_bucket
+{
+  _file=$1
+  _bucket=$2
+  _path=$3
+  _endpoint_url=$4
+
+  _options=
+  if [[ ! -z "${_endpoint_url}" ]]; then
+    _options="--endpoint-url ${_endpoint_url}"
+  fi
+  aws ${_options} s3 cp "${_file}" s3://${_bucket}/${_path}
+}
+
+# This needs expanding etc.
+function check_file_name
+{
+  filename=$1
+  if ( echo ${filename} | grep ^eessi > /dev/null && 
+    echo ${filename} | grep -E '(compat|init|software)' > /dev/null ); then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function create_metadata_file
+{
+  _tarball=$1
+  _url=$2
+  _repository=$3
+  _pull_request=$4
+
+  _tmpfile=$(mktemp)
+
+  jq -n \
+    --arg un $(whoami) \
+    --arg ip $(curl -s https://checkip.amazonaws.com) \
+    --arg hn "$(hostname -f)" \
+    --arg fn "$(basename ${_tarball})" \
+    --arg sz "$(du -b "${_tarball}" | awk '{print $1}')" \
+    --arg ct "$(date -r "${_tarball}")" \
+    --arg sha256 "$(sha256sum "${_tarball}" | awk '{print $1}')" \
+    --arg url "${_url}" \
+    --arg repo "${_repository}" \
+    --arg pr "${_pull_request}" \
+    '{
+       uploader: {username: $un, ip: $ip, hostname: $hn},
+       payload: {filename: $fn, size: $sz, ctime: $ct, sha256sum: $sha256, url: $url},
+       link2pr: {repo: $repo, pr: $pr},
+     }' > "${_tmpfile}"
+
+  echo "${_tmpfile}"
+}
+
+function display_help
+{
+  echo "Usage: $0 [OPTIONS] <filenames>"                                        >&2
+  echo "  -e | --endpoint-url URL      -  endpoint url (needed for non AWS S3)" >&2
+  echo "  -h | --help                  -  display this usage information"       >&2
+  echo "  -n | --bucket-name BUCKET    -  bucket name (same as BUCKET above)"   >&2
+  echo "  -p | --pull-request NUMBER   -  a pull request NUMBER; used to"       >&2
+  echo "                                  link the upload to a PR"              >&2
+  echo "  -r | --repository FULL_NAME  -  a repository name ACCOUNT/REPONAME;"  >&2
+  echo "                                  used to link the upload to a PR"      >&2
+}
+
+if [[ $# -lt 1 ]]; then
+    display_help
+    exit 1
+fi
+
+
+# process command line args
+POSITIONAL_ARGS=()
+
+# depends on which service hosts the bucket
+#   minio: https://MINIO_SERVER:MINIO_PORT/{bucket_name}/
+#   s3aws: https://{bucket_name}.s3.amazonaws.com/
+# should be contructable from endpoint_url and bucket_name
+bucket_base=
+
+# default bucket is eessi-staging
+bucket_name="eessi-staging"
+
+# provided via options in the bot's config file app.cfg
+endpoint_url=
+pull_request=
+repository=
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -e|--endpoint-url)
+      endpoint_url="$2"
+      shift 2
+      ;;
+    -h|--help)
+      display_help
+      exit 0
+      ;;
+    -n|--bucket-name)
+      bucket_name="$2"
+      shift 2
+      ;;
+    -p|--pull-request)
+      pull_request="$2"
+      shift 2
+      ;;
+    -r|--repository)
+      repository="$2"
+      shift 2
+      ;;
+    -*|--*)
+      echo "Error: Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)  # No more options
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift
+      ;;
+  esac
+done
+
+# restore potentially parsed filename(s) into $*
+set -- "${POSITIONAL_ARGS[@]}"
+
+# infer bucket_base:
+#   if endpoint_url is not set (assume AWS S3 is used),
+#     bucket_base=https://${bucket_name}.s3.amazonaws.com/
+#   if endpoint_url is set (assume non AWS S3, eg minio, is used),
+#     bucket_base=${endpoint_url}/${bucket_name}/
+# check if endpoint_url is not set
+if [[ -z "${endpoint_url}" ]]; then
+  # assume AWS S3 being used
+  bucket_base=https://${bucket_name}.s3.amazonaws.com
+else
+  # assume non AWS S3 being used or AWS S3 with bucket not in DNS
+  bucket_base=${endpoint_url}/${bucket_name}
+fi
+
+for file in "$*"; do
+  if [[ -r "${file}" && -f "${file}" &&  -s "${file}" ]]; then
+    basefile=$( basename ${file} )
+    if check_file_name ${basefile}; then
+      if tar tf "${file}" | head -n1 > /dev/null; then
+        aws_path=$(basename ${file} | tr -s '-' '/' \
+                 | perl -pe 's/^eessi.//;' | perl -pe 's/\.tar\.gz$//;' )
+        aws_file=$(basename ${file})
+        echo "Creating metadata file"
+        url="${bucket_base}/${aws_path}/${aws_file}"
+        metadata_file=$(create_metadata_file "${file}" "${url}" \
+                                             "${repository}" "${pull_request}")
+        echo "metadata:"
+        cat ${metadata_file}
+
+        echo Uploading to "${url}"
+        upload_to_staging_bucket \
+                "${file}" \
+                "${bucket_name}" \
+                "${aws_path}/${aws_file}" \
+                "${endpoint_url}"
+        upload_to_staging_bucket \
+                "${metadata_file}" \
+                "${bucket_name}" \
+                "${aws_path}/${aws_file}.meta.txt" \
+                "${endpoint_url}"
+      else
+        echo "'${file}' is not a tar file."
+        exit 1
+      fi
+    else
+      echo "${file} does not look like an eessi layer filename!"
+      exit 1
+    fi
+  else
+      echo "'${file}' is not a readable non zero-sized file."
+      exit 1
+  fi
+done

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -334,18 +334,22 @@ def create_pr_comments(job, job_id, app_name, job_comment, pr, repo_name, gh, sy
         gh (object):github instance
         symlink(string): symlink from main pr_<ID> dir to job dir
     """
-    job_comment = f'Job `{job_id}` on `{app_name}`'
     # obtain arch from job[1] which has the format OS/ARCH
-
     arch_name = '-'.join(job[1].split('/')[1:])
-    job_comment += f' for `{arch_name}`'
-    job_comment += ' in job dir `%s`\n' % symlink
-    job_comment += '|date|job status|comment|\n'
-    job_comment += '|----------|----------|------------------------|\n'
 
+    # get current data/time
     dt = datetime.now(timezone.utc)
-    job_comment += f'|{dt.strftime("%b %d %X %Z %Y")}|submitted|job waits for release by job manager|'
 
+    # construct initial job comment
+    job_comment = (f"New job on instance `{app_name}`"
+                   f" for architecture `{arch_name}`"
+                   f" in job dir `{symlink}`\n"
+                   f"|date|job status|comment|\n"
+                   f"|----------|----------|------------------------|\n"
+                   f"|{dt.strftime('%b %d %X %Z %Y')}|submitted|"
+                   f"job id `{job_id}` awaits release by job manager|")
+
+    # create comment to pull request
     repo = gh.get_repo(repo_name)
     pull_request = repo.get_pull(pr.number)
     pull_request.create_issue_comment(job_comment)

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -261,7 +261,7 @@ def uploaded_before(build_target, job_dir):
     """
     funcname = sys._getframe().f_code.co_name
 
-    log("{funcname}(): any previous uploads for {build_target}?")
+    log(f"{funcname}(): any previous uploads for {build_target}?")
 
     pr_base_dir = os.path.dirname(job_dir)
     uploaded_txt = os.path.join(pr_base_dir, "uploaded.txt")

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -1,0 +1,443 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+import glob
+import os
+import re
+import sys
+
+from connections import github
+from datetime import datetime, timezone
+from pyghee.utils import log, error
+from tools import config, run_cmd
+
+JOBS_BASE_DIR = "jobs_base_dir"
+DEPLOYCFG = "deploycfg"
+UPLOAD_TO_S3_SCRIPT = "upload_to_s3_script"
+ENDPOINT_URL = "endpoint_url"
+BUCKET_NAME = "bucket_name"
+UPLOAD_POLICY = "upload_policy"
+DEPLOY_PERMISSION = "deploy_permission"
+
+
+def determine_job_dirs(pr_number):
+    """Determine job directories of a pull request.
+
+    Args:
+        pr_number (string): number of the pull request
+
+    Returns:
+        job_directories (list): list of directory names
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    job_directories = []
+
+    # job directories are any job IDs under JOBS_BASE_DIR/YYYY.MM/pr_<id>
+    #  - we may have to scan multiple YYYY.MM directories if the PR was
+    #    processed over more than one month
+    #  - we assume that job IDs are positive integer numbers
+    build_env_cfg = get_build_env_cfg()
+    log(f"{funcname}(): jobs_base_dir = {get_build_env_cfg[JOBS_BASE_DIR]}")
+
+    date_pr_job_pattern =
+        f"[0-9][0-9][0-9][0-9].[0-9][0-9]/pr_{pr_number}/[0-9]*"
+    log(f"{funcname}(): date_pr_job_pattern = {date_pr_job_pattern}")
+
+    glob_str = os.path.join(jobs_base_dir, date_pr_job_pattern)
+    log(f"{funcname}(): glob_str = {glob_str}")
+
+    job_directories = glob.glob(glob_str)
+
+    return job_directories
+
+
+def determine_slurm_out(job_dir):
+    """Determine path to slurm*out file for a job given by a job directory.
+
+    Args:
+        job_dir (string): directory of a job
+
+    Returns:
+        slurm_out (string): path to slurm*out file
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    # we assume that the last element (basename) is the job ID
+    slurm_out = os.path.join(job_dir, f"slurm-{os.path.basename(job_dir)}.out")
+    log(f"{funcname}(): slurm out path = '{slurm_out}'")
+
+    return slurm_out
+
+
+def determine_eessi_tarballs(job_dir):
+    """Determine EESSI tarballs.
+
+    Args:
+        job_dir (string): directory of a job
+
+    Returns:
+        eessi_tarballs (list): list of paths to all tarballs in job_dir
+    """
+    # determine all tarballs that are stored in the directory job_dir
+    #   and whose name matches a certain pattern
+    tarball_pattern = "eessi-*software-*.tar.gz"
+    glob_str = os.path.join(job_dir, tarball_pattern)
+    eessi_tarballs = glob.glob(glob_str)
+
+    return eessi_tarballs
+
+
+def check_build_status(slurm_out, eessi_tarballs):
+    """Check status of the job in a given directory.
+
+    Args:
+        slurm_out (string): path to slurm*out file
+        eessi_tarballs (list): list of eessi tarballs found for job
+
+    Returns:
+        (bool): True -> job succeeded, False -> job failed
+    """
+    # Function checks if all modules have been built and if a tarball has
+    # been created.
+
+    # set some initial values
+    no_missing_modules = False
+    targz_created = False
+
+    # check slurm out for the below strings
+    #   ^No missing modules!$ --> all software successfully installed
+    #   ^/eessi_bot_job/eessi-.*-software-.*.tar.gz created!$ -->
+    #     tarball successfully created
+    if os.path.exists(slurm_out):
+        re_missing_modules = re.compile("^No missing modules!$")
+        re_targz_created = re.compile("^/eessi_bot_job/eessi-.*-software-.*.tar.gz created!$")
+        outfile = open(slurm_out, "r")
+        for line in outfile:
+            if re_missing_modules.match(line):
+                # no missing modules
+                no_missing_modules = True
+            if re_targz_created.match(line):
+                # tarball created
+                targz_created = True
+
+    # we test results from the above check and if there is one tarball only
+    if no_missing_modules and targz_created and len(eessi_tarballs) == 1:
+        return True
+
+    return False
+
+
+def update_pr_comment(tarball, repo_name, pr_number, state, msg):
+    """Update PR comment which contains specific tarball name.
+
+    Args:
+        tarball (string): name of tarball that is looked for in a PR comment
+        repo_name (string): name of the repository (USER_ORG/REPOSITORY)
+        pr_number (string): pull request number
+        state (string): state (upload) to be used in update
+        msg (string): msg (succeeded or failed) describing upload result
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    gh = github.get_instance()
+    repo = gh.get_repo(repo_name)
+    pull_request = repo.get_pull(pr_number)
+
+    # TODO does this always return all comments?
+    comments = pull_request.get_issue_comments()
+    for comment in comments:
+        # NOTE
+        # adjust search string if format changed by event handler
+        # (separate process running eessi_bot_event_handler.py)
+        re_tarball = f".*{tarball}.*"
+        comment_match = re.search(re_tarball, comment.body)
+
+        if comment_match:
+            log(f"{funcname}(): found comment with id {comment.id}")
+
+            issue_comment = pull_request.get_issue_comment(int(comment.id))
+
+            dt = datetime.now(timezone.utc)
+            comment_update = (f"\n|{dt.strftime("%b %d %X %Z %Y")}|{state}|"
+                              f"transfer of `{tarball}` to S3 bucket {msg}|")
+
+            # append update to existing comment
+            issue_comment.edit(issue_comment.body + comment_update)
+
+            # leave for loop (only update one comment, because tarball
+            # should only be referenced in one comment)
+            break
+
+
+def append_tarball_to_upload_log(tarball, job_dir):
+    """Append tarball to upload log.
+
+       Args:
+           tarball (string): name of tarball that has been uploaded
+           job_dir (string): directory of the job that built the tarball
+    """
+    # upload log file is 'job_dir/../uploaded.txt'
+    pr_base_dir = os.path.dirname(job_dir)
+    uploaded_txt = os.path.join(pr_base_dir, 'uploaded.txt')
+    with open(uploaded_txt, "a") as upload_log:
+        job_plus_tarball = os.path.join(os.path.basename(job_dir), tarball)
+        uploaded_file.write(f"{job_plus_tarball}\n")
+
+
+def upload_tarball(job_dir, build_target, timestamp, repo_name, pr_number):
+    """Upload built artefact to an S3 bucket.
+
+    Args:
+        job_dir (string): path to the job directory
+        build_target (string): eessi-VERSION-COMPONENT-OS-ARCH
+        timestamp (int): timestamp of the tarball
+        repo_name (string): repository of the pull request
+        pr_number (string): number of the pull request
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    tarball = f"{build_target}-{timestamp}.tar.gz"
+    abs_path = os.join.path(job_dir, tarball)
+    log(f"{funcname}(): deploying build '{abs_path}'")
+
+    # obtain config settings
+    deploycfg = config.get_section(DEPLOYCFG)
+    upload_to_s3_script = deploycfg.get(UPLOAD_TO_S3_SCRIPT)
+    endpoint_url = deploycfg.get(ENDPOINT_URL) or ''
+    bucket_name = deploycfg.get(BUCKET_NAME)
+
+    # run 'eessi-upload-to-staging {abs_path}'
+    # (1) construct command line
+    #   script assumes a few defaults:
+    #     bucket_name = 'eessi-staging'
+    #     if endpoint_url not set use EESSI S3 bucket
+    # (2) run command
+    cmd_args = [ upload_to_s3_script, ]
+    if len(bucket_name) > 0:
+        cmd_args.extend([ '--bucket-name', bucket_name ])
+    if len(endpoint_url) > 0:
+        cmd_args.extend([ '--endpoint-url', endpoint_url ])
+    cmd_args.extend([ '--repository', repo_name ])
+    cmd_args.extend([ '--pull-request', str(pr_number) ])
+    cmd_args.append(abs_path)
+    upload_cmd = ' '.join(cmd_args)
+
+    # run_cmd does all the logging we might need
+    out, err, ec = run_cmd(upload_cmd, 'Upload tarball to S3 bucket')
+
+    if ec == 0:
+        # add file to 'job_dir/../uploaded.txt'
+        append_tarball_to_upload_log(tarball, job_dir)
+        # update pr comment
+        update_pr_comment(tarball, repo_name, pr_number, "upload",
+                          "succeeded")
+    else:
+        # update pr comment
+        update_pr_comment(tarball, repo_name, pr_number, "upload",
+                          "failed")
+
+
+def uploaded_before(build_target, job_dir):
+    """Determines if a tarball for a job has been uploaded before.
+       Function scans the log named 'job_dir/../uploaded.txt' for
+       the string '.*build_target-.*.tar.gz'.
+
+    Args:
+        build_target (string): eessi-VERSION-COMPONENT-OS-ARCH
+        job_dir (string): directory of the job
+
+    Returns:
+        (string): name of the first tarball found if any or None.
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    log("{funcname}(): any previous uploads for {build_target}?")
+
+    pr_base_dir = os.path.dirname(job_dir)
+    uploaded_txt = os.path.join(pr_base_dir, "uploaded.txt")
+
+    if os.path.exists(uploaded_txt):
+        log(f"{funcname}(): upload log '{uploaded_txt}' exists")
+
+        re_string = f".*{build_target}-.*.tar.gz.*"
+        re_build_target = re.compile(re_string)
+
+        with open(uploaded_txt, "r") as uploaded_log:
+            log(f"{funcname}(): scan log for pattern '{re_string}'")
+            for line in uploaded_log:
+                if re_build_target.match(line):
+                    log(f"{funcname}(): found earlier upload {line.strip()}")
+                    return line.strip()
+                else:
+                    log(f"{funcname}(): upload '{line.strip()}' did NOT match")
+            return None
+    else:
+        log(f"{funcname}(): upload log '{uploaded_txt}' does not exist")
+        return None
+
+
+def determine_successful_jobs(job_dirs):
+    """Determine all successful jobs provided in job_dirs.
+
+    Args:
+        job_dirs (list): list of job directories
+
+    Returns:
+        successes (list): list of dictionaries representing successful jobs
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    successes = []
+    for job_dir in job_dirs:
+        slurm_out = determine_slurm_out(job_dir)
+        eessi_tarballs = determine_eessi_tarballs(job_dir)
+        if check_build_status(slurm_out, eessi_tarballs):
+            log(f"{funcname}(): SUCCESSFUL build in '{job_dir}'")
+            successes.append({'job_dir': job_dir,
+                              'slurm_out': slurm_out,
+                              'eessi_tarballs': eessi_tarballs})
+        else:
+            log(f"{funcname}(): FAILED build in '{job_dir}'")
+
+    return successes
+
+
+def determine_tarballs_to_deploy(successes, upload_policy):
+    """Determines tarballs to deploy depending on upload policy
+
+    Args:
+        successes (list): list of dictionaries
+                          {job_dir, slurm_out, eessi_tarballs}
+        upload_policy (string): one of 'all', 'latest' or 'once'
+            'all': deploy all
+            'latest': deploy only the last for each build target
+            'once': deploy only latest if none for this build target has
+                    been deployed before
+    Returns:
+        to_be_deployed (dictionary): dictionary of dictionaries
+                                     {job_dir, timestamp}
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    log(f"{funcname}(): num successful jobs {len(successes)}")
+
+    to_be_deployed = {}
+    for s in successes:
+        # all tarballs for successful job
+        tarballs = s["eessi_tarballs"]
+        log(f"{funcname}(): num tarballs {len(tarballs)}")
+
+        # full path to first tarball for successful job
+        # Note, only one tarball per job is expected.
+        tb0 = tarballs[0]
+        log(f"{funcname}(): path to 1st tarball: '{tb0}'")
+
+        # name of tarball file only
+        tb0_base = os.path.basename(tb0)
+        log(f"{funcname}(): tarball filename: '{tb0_base}'")
+
+        # tarball name format: eessi-VERSION-COMPONENT-OS-ARCH-TIMESTAMP.tar.gz
+        # remove "-TIMESTAMP.tar.gz"
+        # build_target format: eessi-VERSION-COMPONENT-OS-ARCH
+        build_target = "-".join(tb0_base.split("-")[:-1])
+        log(f"{funcname}(): tarball build target '{build_target}'")
+
+        # timestamp in the filename
+        timestamp = int(tb0_base.split("-")[-1][:-7])
+        log(f"{funcname}(): tarball timestamp {timestamp}")
+
+        deploy = False
+        if upload_policy == "all":
+            deploy = True
+        elif upload_policy == "latest":
+            if build_target in to_be_deployed:
+                if to_be_deployed[build_target]["timestamp"] < timestamp:
+                    # current one will be replaced
+                    deploy = True
+            else:
+                deploy = True
+        elif upload_policy == "once":
+            uploaded = uploaded_before(build_target, job_dir)
+            if uploaded is None:
+                deploy = True
+            else:
+                indent_fname = f"{' '*len(funcname + '(): ')}"
+                log(f"{funcname}(): tarball for build target '{build_target}'\n"
+                    f"{indent_fname}has been uploaded through '{uploaded}'")
+
+        if deploy:
+            to_be_deployed[build_target] = {"job_dir": s["job_dir"],
+                                            "timestamp": timestamp}
+
+    return to_be_deployed
+
+
+def deploy_built_artefacts(pr, event_info):
+    """Deploy built artefacts.
+
+    Args:
+        pr (PullRequest): object representing a pull request
+        event_info (dict): dictionary containing event information
+    """
+    funcname = sys._getframe().f_code.co_name
+
+    log(f"{funcname}(): deploy for PR {pr.number}")
+
+    deploycfg = config.get_section(DEPLOYCFG)
+
+    # verify that the GH account that set label bot:deploy has the
+    # permission to trigger the deployment
+    deploy_permission = deploycfg.get(DEPLOY_PERMISSION,'')
+    log(f"{funcname}(): deploy permission '{deploy_permission}'")
+
+    labeler = event_info['sender']['login']
+    if labeler not in deploy_permission.split():
+        log(f"{funcname}(): GH account '{labeler}' is not authorized to deploy")
+        # TODO update PR comments for this bot instance?
+        return
+    else:
+        log(f"{funcname}(): GH account '{labeler}' is authorized to deploy")
+
+    # get upload policy from config
+    upload_policy = deploycfg.get(UPLOAD_POLICY)
+    log(f"{funcname}(): upload policy '{upload_policy}'")
+
+    if upload_policy == "none":
+        return
+
+    # 1) determine what has been built for the PR
+    # 2) for each build check the status of jobs (SUCCESS or FAILURE)
+    # 3) for the successful ones, determine which to deploy depending on policy
+    # 4) call function to deploy a single artefact per software subdir
+
+    # 1) determine what has been built for the PR
+    #    - each job is stored in a directory given by its job ID
+    #    - these job directories are stored under jobs_base_dir/YYYY.MM/pr_<id>
+    #    - multiple YYYY.MM directories may need to be scanned
+    job_dirs = determine_job_dirs(pr.number)
+    log(f"{funcname}(): job_dirs = {','.join(job_dirs)}")
+
+    # 2) for each build check the status of jobs (SUCCESS or FAILURE)
+    #    - scan slurm*out file for: 'No modules missing!' & 'created'
+    successes = determine_successful_jobs(job_dirs)
+
+    # 3) for the successful ones, determine which to deploy depending on
+    #    the upload policy
+    to_be_deployed = determine_tarballs_to_deploy(successes, upload_policy)
+
+    # 4) call function to deploy a single artefact per software subdir
+    #    - update PR comments (look for comments with build-ts.tar.gz)
+    repo_name = pr.base.repo.full_name
+
+    for target, job in to_be_deployed.items():
+        job_dir = job['job_dir']
+        timestamp = job['timestamp']
+        upload_tarball(job_dir, target, timestamp, repo_name, pr.number)

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -207,7 +207,7 @@ def upload_tarball(job_dir, build_target, timestamp, repo_name, pr_number):
     funcname = sys._getframe().f_code.co_name
 
     tarball = f"{build_target}-{timestamp}.tar.gz"
-    abs_path = os.join.path(job_dir, tarball)
+    abs_path = os.path.join(job_dir, tarball)
     log(f"{funcname}(): deploying build '{abs_path}'")
 
     # obtain config settings

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -400,7 +400,7 @@ def deploy_built_artefacts(pr, event_info):
     deploy_permission = deploycfg.get(DEPLOY_PERMISSION, '')
     log(f"{funcname}(): deploy permission '{deploy_permission}'")
 
-    labeler = event_info['sender']['login']
+    labeler = event_info['raw_request_body']['sender']['login']
     if labeler not in deploy_permission.split():
         log(f"{funcname}(): GH account '{labeler}' is not authorized to deploy")
         # TODO update PR comments for this bot instance?

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -239,11 +239,11 @@ def upload_tarball(job_dir, build_target, timestamp, repo_name, pr_number):
         # add file to 'job_dir/../uploaded.txt'
         append_tarball_to_upload_log(tarball, job_dir)
         # update pr comment
-        update_pr_comment(tarball, repo_name, pr_number, "upload",
+        update_pr_comment(tarball, repo_name, pr_number, "uploaded",
                           "succeeded")
     else:
         # update pr comment
-        update_pr_comment(tarball, repo_name, pr_number, "upload",
+        update_pr_comment(tarball, repo_name, pr_number, "not uploaded",
                           "failed")
 
 

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -47,8 +47,8 @@ def determine_job_dirs(pr_number):
     build_env_cfg = get_build_env_cfg()
     log(f"{funcname}(): jobs_base_dir = {get_build_env_cfg[JOBS_BASE_DIR]}")
 
-    date_pr_job_pattern =
-        f"[0-9][0-9][0-9][0-9].[0-9][0-9]/pr_{pr_number}/[0-9]*"
+    date_pr_job_pattern = (f"[0-9][0-9][0-9][0-9].[0-9][0-9]/"
+                           f"pr_{pr_number}/[0-9]*")
     log(f"{funcname}(): date_pr_job_pattern = {date_pr_job_pattern}")
 
     glob_str = os.path.join(jobs_base_dir, date_pr_job_pattern)
@@ -166,7 +166,7 @@ def update_pr_comment(tarball, repo_name, pr_number, state, msg):
             issue_comment = pull_request.get_issue_comment(int(comment.id))
 
             dt = datetime.now(timezone.utc)
-            comment_update = (f"\n|{dt.strftime("%b %d %X %Z %Y")}|{state}|"
+            comment_update = (f"\n|{dt.strftime('%b %d %X %Z %Y')}|{state}|"
                               f"transfer of `{tarball}` to S3 bucket {msg}|")
 
             # append update to existing comment
@@ -220,13 +220,13 @@ def upload_tarball(job_dir, build_target, timestamp, repo_name, pr_number):
     #     bucket_name = 'eessi-staging'
     #     if endpoint_url not set use EESSI S3 bucket
     # (2) run command
-    cmd_args = [ upload_to_s3_script, ]
+    cmd_args = [upload_to_s3_script,]
     if len(bucket_name) > 0:
-        cmd_args.extend([ '--bucket-name', bucket_name ])
+        cmd_args.extend(['--bucket-name', bucket_name])
     if len(endpoint_url) > 0:
-        cmd_args.extend([ '--endpoint-url', endpoint_url ])
-    cmd_args.extend([ '--repository', repo_name ])
-    cmd_args.extend([ '--pull-request', str(pr_number) ])
+        cmd_args.extend(['--endpoint-url', endpoint_url])
+    cmd_args.extend(['--repository', repo_name])
+    cmd_args.extend(['--pull-request', str(pr_number)])
     cmd_args.append(abs_path)
     upload_cmd = ' '.join(cmd_args)
 
@@ -395,7 +395,7 @@ def deploy_built_artefacts(pr, event_info):
 
     # verify that the GH account that set label bot:deploy has the
     # permission to trigger the deployment
-    deploy_permission = deploycfg.get(DEPLOY_PERMISSION,'')
+    deploy_permission = deploycfg.get(DEPLOY_PERMISSION, '')
     log(f"{funcname}(): deploy permission '{deploy_permission}'")
 
     labeler = event_info['sender']['login']


### PR DESCRIPTION
This is based on recent updates/improvements/refactoring of the EESSI bot. It includes the implementation of the deploy step, new configuration settings and their documentation in the README.md.

It is ~still work-in-progress for two reasons~ ready for getting reviewed:
- The documentation ~lacks~ includes information on setting up some tools needed by the upload script.
- It has ~not~ been tested ~yet~.

Nice addition compared to #49 is that the bot can be configured to restrict who can set the `bot:deploy` label.