### PR TITLE
Error handling

### DIFF
--- a/connections/github.py
+++ b/connections/github.py
@@ -11,7 +11,7 @@
 #
 import datetime
 
-from tools import config
+from tools import config, logging
 from github import Github, GithubIntegration
 
 _token = None
@@ -28,9 +28,15 @@ def get_token():
     with open(private_key_path, 'r') as private_key_file:
         private_key = private_key_file.read()
 
-    github_integration = GithubIntegration(app_id, private_key)
-    # Note that installation access tokens last only for 1 hour, you will need to regenerate them after they expire.
-    _token = github_integration.get_access_token(installation_id)
+    # If the config keys are not set, get_access_token will raise a NotImplementedError
+    # Returning NoneType token will stop the connection in get_instance
+    try:
+        github_integration = GithubIntegration(app_id, private_key)
+        # Note that installation access tokens last only for 1 hour, you will need to regenerate them after they expire.
+        _token = github_integration.get_access_token(installation_id)
+    except NotImplementedError as e:
+        logging.error(e)
+        _token = None
 
     return _token
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -84,7 +84,7 @@ class EESSIBotSoftwareLayerJobManager:
                     "reason": job[8],
                 }
                 if current_jobs[job[0]]['state'] in bad_state_codes:
-                    error("Job {} in state {}: {}".format(job[0], job[4], bad_state_messages[job[4]))
+                    error("Job {} in state {}: {}".format(job[0], job[4], bad_state_messages[job[4]]))
 
         return current_jobs
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -89,7 +89,7 @@ class EESSIBotSoftwareLayerJobManager:
                     "reason": job[8],
                 }
                 if state in bad_state_messages:
-                    error("Job {} in state {}: {}".format(job_id, state, bad_state_messages[state]))
+                    log("Job {} in state {}: {}".format(job_id, state, bad_state_messages[state]))
 
         return current_jobs
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -72,6 +72,8 @@ class EESSIBotSoftwareLayerJobManager:
         lines = str(squeue.stdout, "UTF-8").rstrip().split("\n")
         bad_state_messages = {'F': 'Failure', 'OOM': 'Out of Memory', 'TO': 'Time Out'}
         bad_state_codes = bad_state_messages.keys()
+
+        # get job info, logging any Slurm issues
         for i in range(2, len(lines)):
             # assume lines 2 to len(lines) contain jobs
             job = lines[i].rstrip().split()

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -81,13 +81,15 @@ class EESSIBotSoftwareLayerJobManager:
             # assume lines 2 to len(lines) contain jobs
             job = lines[i].rstrip().split()
             if len(job) == 9:
-                current_jobs[job[0]] = {
-                    "jobid": job[0],
-                    "state": job[4],
+                job_id = job[0]
+                state = job[4]
+                current_jobs[job_id] = {
+                    "jobid": job_id,
+                    "state": state,
                     "reason": job[8],
                 }
-                if current_jobs[job[0]]['state'] in bad_state_messages:
-                    error("Job {} in state {}: {}".format(job[0], job[4], bad_state_messages[job[4]]))
+                if state in bad_state_messages:
+                    error("Job {} in state {}: {}".format(job_id, state, bad_state_messages[state]))
 
         return current_jobs
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -68,9 +68,10 @@ class EESSIBotSoftwareLayerJobManager:
         # if any with the following information per job:
         #  jobid, state, nodelist_reason
         # skip first two lines of output ("range(2,...)")
-        # TODO check for errors of squeue call
         current_jobs = {}
         lines = str(squeue.stdout, "UTF-8").rstrip().split("\n")
+        bad_state_messages = {'F': 'Failure', 'OOM': 'Out of Memory', 'TO': 'Time Out'}
+        bad_state_codes = bad_state_messages.keys()
         for i in range(2, len(lines)):
             # assume lines 2 to len(lines) contain jobs
             job = lines[i].rstrip().split()
@@ -80,6 +81,8 @@ class EESSIBotSoftwareLayerJobManager:
                     "state": job[4],
                     "reason": job[8],
                 }
+                if current_jobs[job[0]]['state'] in bad_state_codes:
+                    error("Job {} in state {}: {}".format(job[0], job[4], bad_state_messages[job[4]))
 
         return current_jobs
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -41,11 +41,6 @@ from tools import args, config
 from pyghee.utils import log, error
 
 
-def mkdir(path):
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-
 class EESSIBotSoftwareLayerJobManager:
     "main class for (Slurm) job manager of EESSI bot (separate process)"
 
@@ -522,7 +517,7 @@ class EESSIBotSoftwareLayerJobManager:
         old_symlink = os.path.join(
             self.submitted_jobs_dir, finished_job["jobid"])
         finished_jobs_dir = os.path.join(self.job_ids_dir, "finished")
-        mkdir(finished_jobs_dir)
+        os.makedirs(finished_jobs_dir, exist_ok=True)
         new_symlink = os.path.join(
             finished_jobs_dir, finished_job["jobid"])
         log(
@@ -584,7 +579,7 @@ def main():
         if poll_interval <= 0:
             poll_interval = 60
         job_manager.scontrol_command = job_mgr.get("scontrol_command") or False
-        mkdir(job_manager.submitted_jobs_dir)
+        os.makedirs(job_manager.submitted_jobs_dir, exist_ok=True)
 
     # max_iter
     #   < 0: run loop indefinitely

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -71,8 +71,6 @@ class EESSIBotSoftwareLayerJobManager:
         current_jobs = {}
         lines = str(squeue.stdout, "UTF-8").rstrip().split("\n")
         bad_state_messages = {'F': 'Failure', 'OOM': 'Out of Memory', 'TO': 'Time Out'}
-        bad_state_codes = bad_state_messages.keys()
-
         # get job info, logging any Slurm issues
         for i in range(2, len(lines)):
             # assume lines 2 to len(lines) contain jobs
@@ -83,7 +81,7 @@ class EESSIBotSoftwareLayerJobManager:
                     "state": job[4],
                     "reason": job[8],
                 }
-                if current_jobs[job[0]]['state'] in bad_state_codes:
+                if current_jobs[job[0]]['state'] in bad_state_messages:
                     error("Job {} in state {}: {}".format(job[0], job[4], bad_state_messages[job[4]]))
 
         return current_jobs

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -30,17 +30,6 @@ LOCAL_TMP = "local_tmp"
 SLURM_PARAMS = "slurm_params"
 SUBMIT_COMMAND = "submit_command"
 
-
-def mkdir(path):
-    """create directory on the path passed to the method
-
-    Args:
-        path (string): location to where the directory is being created
-    """
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-
 def get_build_env_cfg():
     """Gets build environment values
 
@@ -136,13 +125,13 @@ def create_pr_dir(pr, jobs_base_dir, event_info):
     pr_id = 'pr_%s' % pr.number
     event_id = 'event_%s' % event_info['id']
     event_dir = os.path.join(jobs_base_dir, ym, pr_id, event_id)
-    mkdir(event_dir)
+    os.makedirs(event_dir, exist_ok=True)
 
     run = 0
     while os.path.exists(os.path.join(event_dir, 'run_%03d' % run)):
         run += 1
     run_dir = os.path.join(event_dir, 'run_%03d' % run)
-    mkdir(run_dir)
+    os.makedirs(run_dir, exist_ok=True)
     return ym, pr_id, run_dir
 
 
@@ -231,7 +220,7 @@ def setup_pr_in_arch_job_dir(pr, arch_target_map, run_dir, cvmfs_customizations)
     for arch_target, slurm_opt in arch_target_map.items():
         arch_job_dir = os.path.join(run_dir, arch_target.replace('/', '_'))
 
-        mkdir(arch_job_dir)
+        os.makedirs(arch_job_dir, exist_ok=True)
         log("arch_job_dir '%s'" % arch_job_dir)
 
         download_pr(repo_name, branch_name, pr, arch_job_dir)

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -30,6 +30,7 @@ LOCAL_TMP = "local_tmp"
 SLURM_PARAMS = "slurm_params"
 SUBMIT_COMMAND = "submit_command"
 
+
 def get_build_env_cfg():
     """Gets build environment values
 

--- a/test.sh
+++ b/test.sh
@@ -7,4 +7,4 @@
 #
 # license: GPLv2
 #
-PYTHONPATH=$PWD:$PYTHONPATH pytest -vv -s
+PYTHONPATH=$PWD:$PYTHONPATH pytest -v -s

--- a/test.sh
+++ b/test.sh
@@ -7,4 +7,4 @@
 #
 # license: GPLv2
 #
-PYTHONPATH=$PWD:$PYTHONPATH pytest -v -s
+PYTHONPATH=$PWD:$PYTHONPATH pytest -vv -s

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -9,9 +9,9 @@
 #
 # license: GPLv2
 #
-import os
 
 from tools import run_subprocess
+
 
 def test_run_cmd(tmpdir):
     """Tests for run_cmd function."""

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -6,6 +6,7 @@
 #
 # author: Kenneth Hoste (@boegel)
 # author: Hafsa Naeem (@hafsa-naeem)
+# author: Jacob Ziemke (@jacobz137)
 #
 # license: GPLv2
 #
@@ -13,8 +14,8 @@
 from tools import run_subprocess
 
 
-def test_run_cmd(tmpdir):
-    """Tests for run_cmd function."""
+def test_run_subprocess(tmpdir):
+    """Tests for run_subprocess function."""
     output, err, exit_code = run_subprocess("echo hello", 'test', tmpdir)
     assert exit_code == 0
     assert output == "hello\n"

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -11,21 +11,21 @@
 #
 import os
 
-from tools import run_cmd
+from tools import run_subprocess
 
 def test_run_cmd(tmpdir):
     """Tests for run_cmd function."""
-    output, err, exit_code = run_cmd("echo hello", 'test', tmpdir)
+    output, err, exit_code = run_subprocess("echo hello", 'test', tmpdir)
     assert exit_code == 0
     assert output == "hello\n"
     assert err == ""
 
-    output, err,  exit_code, = run_cmd("ls -l /does_not_exists.txt", 'fail test', tmpdir)
+    output, err,  exit_code, = run_subprocess("ls -l /does_not_exists.txt", 'fail test', tmpdir)
     assert exit_code != 0
     assert output == ""
     assert "No such file or directory" in err
 
-    output, err, exit_code = run_cmd("this_command_does_not_exist", 'fail test', tmpdir)
+    output, err, exit_code = run_subprocess("this_command_does_not_exist", 'fail test', tmpdir)
     assert exit_code != 0
     assert output == ""
     assert ("this_command_does_not_exist: command not found" in err or "this_command_does_not_exist: not found" in err)

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -16,16 +16,20 @@ from tools import run_subprocess
 def test_run_cmd(tmpdir):
     """Tests for run_cmd function."""
     output, err, exit_code = run_subprocess("echo hello", 'test', tmpdir)
+    print(output, err, exit_code)
+
     assert exit_code == 0
     assert output == "hello\n"
     assert err == ""
 
     output, err,  exit_code, = run_subprocess("ls -l /does_not_exists.txt", 'fail test', tmpdir)
+    print(output, err, exit_code)
     assert exit_code != 0
     assert output == ""
     assert "No such file or directory" in err
 
     output, err, exit_code = run_subprocess("this_command_does_not_exist", 'fail test', tmpdir)
+    print(output, err, exit_code)
     assert exit_code != 0
     assert output == ""
     assert ("this_command_does_not_exist: command not found" in err or "this_command_does_not_exist: not found" in err)

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -11,32 +11,7 @@
 #
 import os
 
-from tasks.build import mkdir
 from tools import run_cmd
-
-
-def test_mkdir(tmpdir):
-    """Tests for mkdir function."""
-    test_dir = os.path.join(tmpdir, 'test')
-    mkdir(test_dir)
-    assert os.path.isdir(test_dir)
-
-    # parent directories are created if needed
-    deep_test_dir = os.path.join(tmpdir, 'one', 'two', 'three')
-    assert not os.path.exists(os.path.dirname(os.path.dirname(deep_test_dir)))
-    mkdir(deep_test_dir)
-    assert os.path.isdir(deep_test_dir)
-
-    # calling mkdir on an existing path is fine (even if that path is a file?!)
-    mkdir(test_dir)
-    assert os.path.isdir(test_dir)
-    test_file = os.path.join(tmpdir, 'test.txt')
-    with open(test_file, 'w') as fp:
-        fp.write('')
-
-    mkdir(test_file)
-    assert os.path.isfile(test_file)
-
 
 def test_run_cmd(tmpdir):
     """Tests for run_cmd function."""

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -16,20 +16,16 @@ from tools import run_subprocess
 def test_run_cmd(tmpdir):
     """Tests for run_cmd function."""
     output, err, exit_code = run_subprocess("echo hello", 'test', tmpdir)
-    print(output, err, exit_code)
-
     assert exit_code == 0
     assert output == "hello\n"
     assert err == ""
 
     output, err,  exit_code, = run_subprocess("ls -l /does_not_exists.txt", 'fail test', tmpdir)
-    print(output, err, exit_code)
     assert exit_code != 0
     assert output == ""
     assert "No such file or directory" in err
 
     output, err, exit_code = run_subprocess("this_command_does_not_exist", 'fail test', tmpdir)
-    print(output, err, exit_code)
     assert exit_code != 0
     assert output == ""
     assert ("this_command_does_not_exist: command not found" in err or "this_command_does_not_exist: not found" in err)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -16,6 +16,7 @@ import subprocess
 
 from pyghee.utils import log
 
+
 def run_cmd(cmd, log_msg='', working_dir=None):
     """Runs a command in the shell, raising an error if one occurs.
 
@@ -34,7 +35,7 @@ def run_cmd(cmd, log_msg='', working_dir=None):
     stdout, stderr, exit_code = run_subprocess(cmd, log_msg, working_dir)
 
     if exit_code != 0:
-        error_msg=(
+        error_msg = (
             f"run_cmd(): Error running '{cmd}' in '{working_dir}\n"
             f"           stdout '{stdout}'\n"
             f"           stderr '{stderr}'\n"
@@ -49,6 +50,7 @@ def run_cmd(cmd, log_msg='', working_dir=None):
             f"           exit code {exit_code}")
 
     return stdout, stderr, exit_code
+
 
 def run_subprocess(cmd, log_msg, working_dir):
     """Runs a command in the shell

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -71,9 +71,9 @@ def run_subprocess(cmd, log_msg, working_dir):
         working_dir = os.getcwd()
 
     if log_msg:
-        log(f"run_cmd(): '{log_msg}' by running '{cmd}' in directory '{working_dir}'")
+        log(f"run_subprocess(): '{log_msg}' by running '{cmd}' in directory '{working_dir}'")
     else:
-        log(f"run_cmd(): Running '{cmd}' in directory '{working_dir}'")
+        log(f"run_subprocess(): Running '{cmd}' in directory '{working_dir}'")
 
     result = subprocess.run(cmd,
                             cwd=working_dir,

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -53,7 +53,7 @@ def run_cmd(cmd, log_msg='', working_dir=None):
 
 
 def run_subprocess(cmd, log_msg, working_dir):
-    """Runs a command in the shell
+    """Runs a command in the shell. No error is raised if the command fails, the exit code is returned in all scenarios.
 
     Args:
         cmd (string): command to run

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -16,8 +16,41 @@ import subprocess
 
 from pyghee.utils import log
 
-
 def run_cmd(cmd, log_msg='', working_dir=None):
+    """Runs a command in the shell, raising an error if one occurs.
+
+    Args:
+        cmd (string): command to run
+        log_msg (string): purpose of the command
+        working_dir (string): location of arch_job_dir
+
+    Returns:
+        tuple of 3 elements containing
+        - stdout (string): stdout of the process
+        - stderr (string): stderr of the process
+        - exit_code (string): exit code of the process
+    """
+
+    stdout, stderr, exit_code = run_subprocess(cmd, log_msg, working_dir)
+
+    if exit_code != 0:
+        error_msg=(
+            f"run_cmd(): Error running '{cmd}' in '{working_dir}\n"
+            f"           stdout '{stdout}'\n"
+            f"           stderr '{stderr}'\n"
+            f"           exit code {exit_code}"
+        )
+        log(error_msg)
+        raise RuntimeError(error_msg)
+    else:
+        log(f"run_cmd(): Result for running '{cmd}' in '{working_dir}\n"
+            f"           stdout '{stdout}'\n"
+            f"           stderr '{stderr}'\n"
+            f"           exit code {exit_code}")
+
+    return stdout, stderr, exit_code
+
+def run_subprocess(cmd, log_msg, working_dir):
     """Runs a command in the shell
 
     Args:
@@ -31,6 +64,7 @@ def run_cmd(cmd, log_msg='', working_dir=None):
         - stderr (string): stderr of the process
         - exit_code (string): exit code of the process
     """
+
     if working_dir is None:
         working_dir = os.getcwd()
 
@@ -47,20 +81,5 @@ def run_cmd(cmd, log_msg='', working_dir=None):
     stdout = result.stdout.decode("UTF-8")
     stderr = result.stderr.decode("UTF-8")
     exit_code = result.returncode
-
-    if exit_code != 0:
-        error_msg=(
-            f"run_cmd(): Error running '{cmd}' in '{working_dir}\n"
-            f"           stdout '{stdout}'\n"
-            f"           stderr '{stderr}'\n"
-            f"           exit code {exit_code}"
-        )
-        log(error_msg)
-        raise RuntimeError(error_msg)
-    else:
-        log(f"run_cmd(): Result for running '{cmd}' in '{working_dir}\n"
-            f"           stdout '{stdout}'\n"
-            f"           stderr '{stderr}'\n"
-            f"           exit code {exit_code}")
 
     return stdout, stderr, exit_code

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -49,10 +49,14 @@ def run_cmd(cmd, log_msg='', working_dir=None):
     exit_code = result.returncode
 
     if exit_code != 0:
-        log(f"run_cmd(): Error running '{cmd}' in '{working_dir}\n"
+        error_msg=(
+            f"run_cmd(): Error running '{cmd}' in '{working_dir}\n"
             f"           stdout '{stdout}'\n"
             f"           stderr '{stderr}'\n"
-            f"           exit code {exit_code}")
+            f"           exit code {exit_code}"
+        )
+        log(error_msg)
+        raise RuntimeError(error_msg)
     else:
         log(f"run_cmd(): Result for running '{cmd}' in '{working_dir}\n"
             f"           stdout '{stdout}'\n"

--- a/tools/config.py
+++ b/tools/config.py
@@ -20,9 +20,9 @@ def read_file(path):
     Read a given configuration file.
     """
     global _config
-    _config = configparser.ConfigParser()
     try:
-        _config.read(path)
+        _config = configparser.ConfigParser()
+        _config.read_file(path)
     except Exception as e:
         print(e)
         error(f'Unable to read configuration file {path}!')

--- a/tools/config.py
+++ b/tools/config.py
@@ -22,7 +22,7 @@ def read_file(path):
     global _config
     try:
         _config = configparser.ConfigParser()
-        _config.read_file(path)
+        _config.read(path)
     except Exception as e:
         print(e)
         error(f'Unable to read configuration file {path}!')


### PR DESCRIPTION
The following changes have been made:
 - On error, run_cmd raises a RuntimeError in addition to logging the error message.
 - Slurm errors are logged in the case of states "Failure", "Out of Memory" or "Time Out". I opted not to log issues due to "Pending: ReqNodeNotAvail", because this can either mean that the node is fully in use and is unable to run any more jobs, which isn't an error, or it can mean that there is a problem with the node and it is offline. I did not see a way to differentiate between these two cases. A "warning" could be appropriate here, but I thought that may be annoying if it happens too often.
 - Errors are logged when token creation fails, due to missing configuration parameters.
 - From what I could tell, /tools/config.py was using the wrong method to read the config file, but maybe I misunderstood the purpose.
 - The mkdirs method defined in /tasks/build.py and again in eessi_bot_job_manager.py looks like it can be accomplished with os.makedirs' exist_ok parameter.

If there's anything else that should go into this, let me know.
