### PR TITLE
use .diff patch file to set up build job working directory

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -178,8 +178,8 @@ def download_pr(repo_name, branch_name, pr, arch_job_dir):
     curl_cmd = f'curl -L https://github.com/{repo_name}/pull/{pr.number}.diff > {pr.number}.diff'
     curl_output, curl_error, curl_exit_code = run_cmd(curl_cmd, "Obtain patch", arch_job_dir)
 
-    git_am_cmd = f'git am {pr.number}.diff'
-    git_am_output, git_am_error, git_am_exit_code = run_cmd(git_am_cmd, "Apply patch", arch_job_dir)
+    git_apply_cmd = f'git apply {pr.number}.diff'
+    git_apply_output, git_apply_error, git_apply_exit_code = run_cmd(git_apply_cmd, "Apply patch", arch_job_dir)
 
 
 def apply_cvmfs_customizations(cvmfs_customizations, arch_job_dir):

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -175,10 +175,10 @@ def download_pr(repo_name, branch_name, pr, arch_job_dir):
     checkout_output, checkout_err, checkout_exit_code = run_cmd(git_checkout_cmd,
                                                                 "checkout branch '%s'" % branch_name, arch_job_dir)
 
-    curl_cmd = f'curl -L https://github.com/{repo_name}/pull/{pr.number}.patch > {pr.number}.patch'
+    curl_cmd = f'curl -L https://github.com/{repo_name}/pull/{pr.number}.diff > {pr.number}.diff'
     curl_output, curl_error, curl_exit_code = run_cmd(curl_cmd, "Obtain patch", arch_job_dir)
 
-    git_am_cmd = f'git am {pr.number}.patch'
+    git_am_cmd = f'git am {pr.number}.diff'
     git_am_output, git_am_error, git_am_exit_code = run_cmd(git_am_cmd, "Apply patch", arch_job_dir)
 
 


### PR DESCRIPTION
The `.patch` patch file contains individual commits, rather than just a `diff` against current target branch, see https://github.com/EESSI/software-layer/pull/210.patch vs https://github.com/EESSI/software-layer/pull/210.diff

By using `.patch`, problems pop up when trying to apply the patch if merge conflicts were involved in the PR.
That shouldn't be a problem when using the `.diff` patch file instead to set up the build job directory...