### PR TITLE
support for sending commands to bot instances via PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,27 @@ submit_command = /usr/bin/sbatch
 ```
 This is the full path to the Slurm command used for submitting batch jobs. You may want to verify if `sbatch` is provided at that path or determine its actual location (`which sbatch`).
 
+### Section `[bot_control]`
+The section `[bot_control]` contains settings for configuring the feature to
+send commands to the bot.
+```
+command_permission = GH_ACCOUNT_1 GH_ACCOUNT_2 ...
+```
+The option `command_permission` defines which GitHub accounts can send commands
+to the bot (via new PR comments). If the value is empty NO account can send
+commands.
+
+```
+command_response_fmt = FORMAT_MARKDOWN_AND_HTML
+```
+This allows to customize the format of the comments about the handling of bot
+commands. The format needs to include `{sender}`, `{comment_response}` and
+`{comment_result}`. `{app_name}` is replaced with the name of the bot instance.
+`{comment_response}` is replaced with information about parsing the comment
+for commands before any command is run. `{comment_result}` is replaced with
+information about the result of the command that was run (can be empty).
+
+
 ### Section `[deploycfg]`
 The section `[deploycfg]` defines settings for uploading built artefacts (tarballs).
 ```

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -33,7 +33,8 @@ private_key = PATH_TO_PRIVATE_KEY
 #   endless loop.
 command_permission =
 
-# format of the response when processing bot commands
+# format of the response when processing bot commands. NOTE, make sure the
+# placeholders {app_name}, {comment_response} and {comment_result} are included.
 command_response_fmt =
     <details><summary>Updates by the bot instance <code>{app_name}</code>
     <em>(click for details)</em></summary>

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -24,6 +24,25 @@ installation_id = 12345678
 private_key = PATH_TO_PRIVATE_KEY
 
 
+[bot_control]
+# which GH accounts have the permission to send commands to the bot
+# if value is left/empty everyone can send commands
+# value can be a space delimited list of GH accounts
+# NOTE, be careful to not list the bot's name (GH app name) or it may consider
+#   comments created/updated by itself as a bot command and thus enter an
+#   endless loop.
+command_permission =
+
+# format of the response when processing bot commands
+command_response_fmt =
+    <details><summary>Updates by the bot instance <code>{app_name}</code>
+    <em>(click for details)</em></summary>
+
+    {comment_response}
+    {comment_result}
+    </details>
+
+
 [buildenv]
 # name of the job script used for building an EESSI stack
 build_job_script = PATH_TO_EESSI_BOT/scripts/bot-build.slurm

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -125,7 +125,7 @@ class EESSIBotSoftwareLayer(PyGHee):
                     continue
                 commands.append(ebc)
                 self.log(f"found bot command: '{bot_command}'")
-                comment_response += "\n- received bot command `{bot_command}`"
+                comment_response += f"\n- received bot command `{bot_command}`"
                 comment_response += f" from `{sender}`"
                 comment_response += f"\n  - expanded format: `{ebc.to_string()}`"
             # FIXME add an else branch that logs information for comments not
@@ -170,13 +170,14 @@ class EESSIBotSoftwareLayer(PyGHee):
         for cmd in commands:
             try:
                 update = self.handle_bot_command(event_info, cmd)
-                comment_result += f"\n- handling `{cmd.command}` resulted in: "
-                comment_result += update
-                self.log(f"handling '{cmd.command}' resulted in '{update}'")
+                comment_result += f"\n- handling command `{cmd.to_string()}` resulted in: "
+                comment_result += f"\n  - {update}"
+                self.log(f"handling command '{cmd.to_string()}' resulted in '{update}'")
 
-            except EESSIBotCommandError as bce:
-                self.log(f"ERROR: handling {cmd.command} failed with {bce.args}")
-                comment_result += f"\n- handling `{cmd.command}` failed with {bce.args}"
+            except EESSIBotCommandError as err:
+                self.log(f"ERROR: handling command {cmd.command} failed with {err.args[0]}")
+                comment_result += f"\n- handling command `{cmd.command}` failed with message"
+                comment_result += f"\n  _{err.args[0]}_"
                 continue
             except Exception as err:
                 log(f"Unexpected err={err}, type(err)={type(err)}")
@@ -296,7 +297,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             return handler(event_info, bot_command)
         else:
             self.log(f"No handler for command '{cmd}'")
-            raise EESSIBotCommandError(f"unknown command '{cmd}'; use `bot: help` for usage information")
+            raise EESSIBotCommandError(f"unknown command `{cmd}`; use `bot: help` for usage information")
 
     def handle_bot_command_help(self, event_info, bot_command):
         """handles command 'bot: help' with a simple usage info"""
@@ -332,7 +333,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         pr_number = event_info['raw_request_body']['issue']['number']
         pr = gh.get_repo(repo_name).get_pull(pr_number)
         issue_comment = self.handle_pull_request_opened_event(event_info, pr)
-        return f"added comment {issue_comment.issue_url} to show configuration"
+        return f"added comment {issue_comment.html_url} to show configuration"
 
     def start(self, app, port=3000):
         """starts the app and log information in the log file

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -176,15 +176,17 @@ class EESSIBotSoftwareLayer(PyGHee):
         for cmd in commands:
             try:
                 update = self.handle_bot_command(event_info, cmd)
-                # next two lines commented out to make the bot less noisy,
-                # could be enabled again if bot commands accept arg --verbose
-                # or bot instance has a similar setting; those were also a bit
-                # confusing when different instances overwrote comments of the
-                # other instances
-                # comment_update += f"\n- handling `{cmd.command}` resulted in: "
-                # comment_update += update
-                # update_pr_comment(event_info, comment_update)
+                # the update to the PR comment is only done if the command is
+                # 'help'; otherwise there was too much noise and also updates
+                # were a bit confusing when different instances overwrote
+                # comments of the other instances
+                if cmd.command == 'help':
+                    comment_update += f"\n- handling `{cmd.command}` resulted in: "
+                    comment_update += update
+                    update_pr_comment(event_info, comment_update)
+
                 self.log(f"handling '{cmd.command}' resulted in '{update}'")
+
             except EESSIBotCommandError as bce:
                 self.log(f"ERROR: handling {cmd.command} failed with {bce.args}")
                 # next two lines commented out to make the bot less noisy,

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -135,6 +135,8 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log("update to comment is empty")
             return
 
+        comment_update += f"\n<!-- ADD NEW COMMENTS BELOW THIS LINE -->\n"
+
         if not any(map(get_bot_command, comment_update.split('\n'))):
             # the 'not any()' ensures that the update would not be considered a bot command itself
             # ... together with checking the sender of a comment update this aims

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -103,13 +103,21 @@ class EESSIBotSoftwareLayer(PyGHee):
         #      run the update through the function checking for a bot command.
         if check_command_permission(sender) is False:
             self.log(f"account `{sender}` has NO permission to send commands to bot")
-            comment_response = f"\n- account `{sender}` has NO permission to send commands to the bot"
-            comment_body = command_response_fmt.format(
-                app_name=app_name,
-                comment_response=comment_response,
-                comment_result=''
-            )
-            issue_comment = create_comment(repo_name, pr_number, comment_body)
+            # need to ensure that the bot is not responding on its own comments
+            # as a quick implementation we check if the sender name contains '[bot]'
+            # FIXME improve this by querying (and caching) information about the sender of
+            #       an event ALTERNATIVELY we could postpone this test a bit until we
+            #       have parsed the comment and know if it contains any bot command
+            if not sender.endswith('[bot]'):
+                comment_response = f"\n- account `{sender}` has NO permission to send commands to the bot"
+                comment_body = command_response_fmt.format(
+                    app_name=app_name,
+                    comment_response=comment_response,
+                    comment_result=''
+                )
+                issue_comment = create_comment(repo_name, pr_number, comment_body)
+            else:
+                self.log(f"account `{sender}` seems to be a bot instance itself, hence not creating a new PR comment")
             return
         else:
             self.log(f"account `{sender}` has permission to send commands to bot")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -81,9 +81,11 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment created: '{comment_diff}'")
         elif action == 'edited':
             comment_old = request_body['changes']['body']['from']
+            self.log(f"comment edited: OLD '{comment_old}'")
             comment_new = request_body['comment']['body']
+            self.log(f"comment edited: NEW '{comment_new}'")
             comment_diff = comment_new.replace(comment_old, '')
-            self.log(f"comment edited: '{comment_diff}'")
+            self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):
             self.log(f"searching line '{line}' for bot command")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -223,7 +223,8 @@ class EESSIBotSoftwareLayer(PyGHee):
         gh = github.get_instance()
         repo = gh.get_repo(repo_name)
         pull_request = repo.get_pull(pr.number)
-        pull_request.create_issue_comment(comment)
+        comment = pull_request.create_issue_comment(comment)
+        return comment.id
 
     def handle_pull_request_event(self, event_info, log_file=None):
         """
@@ -267,7 +268,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         help_msg += "\n  - Commands must be sent with a **new** comment (edits of existing comments are ignored)."
         help_msg += "\n  - A comment may contain multiple commands, one per line."
         help_msg += "\n  - Every command begins at the start of a line and has the syntax `bot: COMMAND [ARGUMENTS]*`"
-        help_msg += "\n  - Currently supported COMMANDs are: `help`"
+        help_msg += "\n  - Currently supported COMMANDs are: `help`, `build`, `showconfig`"
         return help_msg
 
     def handle_bot_command_build(self, event_info, bot_command):
@@ -301,8 +302,14 @@ class EESSIBotSoftwareLayer(PyGHee):
 #    def handle_bot_command_status(self, event_info, bot_command):
 #        return
 
-#    def handle_bot_command_show_config(self, event_info, bot_command):
-#        return
+    def handle_bot_command_showconfig(self, event_info, bot_command):
+        self.log("processing bot command 'showconfig'")
+        gh = github.get_instance()
+        repo_name = event_info['raw_request_body']['repository']['full_name']
+        pr_number = event_info['raw_request_body']['pull_request']['number']
+        pr = gh.get_repo(repo_name).get_pull(pr_number)
+        comment_id = self.handle_pull_request_opened_event(event_info, pr)
+        return f"added comment #{comment_id} to show configuration"
 
     def start(self, app, port=3000):
         """starts the app and log information in the log file

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -89,10 +89,10 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"searching line '{line}' for bot command")
             match = re.search('^bot: (.*)$', line)
             if match:
-                self.log(f"found bot command: {match.group(1)}")
+                self.log(f"found bot command: '{match.group(1)}'")
                 comment_update += "<hr/>\n received bot command "
                 comment_update += f"{match.group(1)}\n"
-        self.log(f"comment update: {comment_update}")
+        self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']
             pr_number = int(request_body['issue']['number'])

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -127,9 +127,9 @@ class EESSIBotSoftwareLayer(PyGHee):
                 try:
                     ebc = EESSIBotCommand(bot_command)
                 except EESSIBotCommandError as bce:
-                    self.log(f"ERROR: parsing {bot_command=} failed with {bce.args}")
-                    comment_update += f"\n- parsing `{bot_command=}` received"
-                    comment_update += f" from `{sender=}` failed"
+                    self.log(f"ERROR: parsing bot command '{bot_command}' failed with {bce.args}")
+                    comment_update += f"\n- parsing bot command `{bot_command}` received"
+                    comment_update += f" from sender `{sender}` failed"
                     continue
                 commands.append(ebc)
                 self.log(f"found bot command: '{bot_command}'")
@@ -171,7 +171,7 @@ class EESSIBotSoftwareLayer(PyGHee):
                 update_pr_comment(event_info, comment_update)
                 continue
             except Exception as err:
-                log(f"Unexpected {err=}, {type(err)=}")
+                log(f"Unexpected err={err}, type(err)={type(err)}")
                 raise
 
         self.log("issue_comment event handled!")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -94,8 +94,8 @@ class EESSIBotSoftwareLayer(PyGHee):
             match = re.search('^bot: (.*)$', line)
             if match:
                 self.log(f"found bot command: '{match.group(1)}'")
-                comment_update += "\n<hr/>\n- received bot command "
-                comment_update += f"`{match.group(1)}`\n"
+                comment_update += "\n- received bot command "
+                comment_update += f"`{match.group(1)}`"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -275,7 +275,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         gh = github.get_instance()
         self.log("repository: '%s'", event_info['raw_request_body']['repository']['full_name'])
         repo_name = event_info['raw_request_body']['repository']['full_name']
-        pr_number = event_info['raw_request_body']['pull_request']['number']
+        pr_number = event_info['raw_request_body']['issue']['number']
         pr = gh.get_repo(repo_name).get_pull(pr_number)
         build_msg = ''
         if check_build_permission(pr, event_info):
@@ -306,7 +306,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         self.log("processing bot command 'showconfig'")
         gh = github.get_instance()
         repo_name = event_info['raw_request_body']['repository']['full_name']
-        pr_number = event_info['raw_request_body']['pull_request']['number']
+        pr_number = event_info['raw_request_body']['issue']['number']
         pr = gh.get_repo(repo_name).get_pull(pr_number)
         comment_id = self.handle_pull_request_opened_event(event_info, pr)
         return f"added comment #{comment_id} to show configuration"

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -86,7 +86,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: NEW '{comment_new}'")
             if len(comment_old) < len(comment_new):
                 comment_diff = comment_new[len(comment_old):]
-                self.log(f"comment edited: NEW shorter than OLD (assume cleanup -> no action)")
+                self.log("comment edited: NEW shorter than OLD (assume cleanup -> no action)")
             self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):
@@ -95,7 +95,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             if match:
                 self.log(f"found bot command: '{match.group(1)}'")
                 comment_update += "\n- received bot command "
-                comment_update += f"`{match.group(1)}`"
+                comment_update += f"`{match.group(1).rstrip()}`"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -105,6 +105,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: NEW '{comment_new}'")
             if len(comment_old) < len(comment_new):
                 comment_diff = comment_new[len(comment_old):]
+            else:
                 self.log("comment edited: NEW shorter than OLD (assume cleanup -> no action)")
             self.log(f"comment edited: DIFF '{comment_diff}'")
 
@@ -123,9 +124,9 @@ class EESSIBotSoftwareLayer(PyGHee):
             else:
                 self.log(f"`{line}` is not considered to contain a bot command")
                 # TODO keep the below for debugging purposes
-                comment_update += "\n- line `{line}` is not considered to contain a bot command"
-                comment_update += "\n  bot commands begin with `bot: `, make sure"
-                comment_update += "\n  there is no whitespace at the beginning of a line"
+                #comment_update += "\n- line <code>{line}</code> is not considered to contain a bot command"
+                #comment_update += "\n  bot commands begin with `bot: `, make sure"
+                #comment_update += "\n  there is no whitespace at the beginning of a line"
         self.log(f"comment update: '{comment_update}'")
         if comment_update == '':
             # no update to be added, just log and return

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -84,7 +84,9 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: OLD '{comment_old}'")
             comment_new = request_body['comment']['body']
             self.log(f"comment edited: NEW '{comment_new}'")
-            comment_diff = comment_new[len(comment_old):]
+            if len(comment_old) < len(comment_new):
+                comment_diff = comment_new[len(comment_old):]
+                self.log(f"comment edited: NEW shorter than OLD (assume cleanup -> no action)")
             self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):
@@ -92,8 +94,8 @@ class EESSIBotSoftwareLayer(PyGHee):
             match = re.search('^bot: (.*)$', line)
             if match:
                 self.log(f"found bot command: '{match.group(1)}'")
-                comment_update += "<hr/>\n received bot command "
-                comment_update += f"{match.group(1)}\n"
+                comment_update += "\n<hr/>\n- received bot command "
+                comment_update += f"`{match.group(1)}`\n"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -19,7 +19,7 @@ import tasks.build as build
 import tasks.deploy as deploy
 
 from connections import github
-from tasks.build import check_build_permission, get_architecturetargets, get_repo_cfg, submit_build_jobs
+from tasks.build import check_build_permission, get_architecture_targets, get_repo_cfg, submit_build_jobs
 from tasks.deploy import deploy_built_artefacts
 from tools import config
 from tools.args import event_handler_parse
@@ -238,7 +238,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         app_name = self.cfg[GITHUB][APP_NAME]
         # TODO check if PR already has a comment with arch targets and
         # repositories
-        arch_map = get_architecturetargets(self.cfg)
+        arch_map = get_architecture_targets(self.cfg)
         repo_cfg = get_repo_cfg(self.cfg)
 
         comment = f"Instance `{app_name}` is configured to build:"

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -128,8 +128,11 @@ class EESSIBotSoftwareLayer(PyGHee):
                     ebc = EESSIBotCommand(bot_command)
                 except EESSIBotCommandError as bce:
                     self.log(f"ERROR: parsing bot command '{bot_command}' failed with {bce.args}")
-                    comment_update += f"\n- parsing bot command `{bot_command}` received"
-                    comment_update += f" from sender `{sender}` failed"
+                    # next two lines commented out to make the bot less noisy,
+                    # could be enabled again if bot commands accept arg --verbose
+                    # or bot instance has a similar setting
+                    # comment_update += f"\n- parsing bot command `{bot_command}` received"
+                    # comment_update += f" from sender `{sender}` failed"
                     continue
                 commands.append(ebc)
                 self.log(f"found bot command: '{bot_command}'")
@@ -138,10 +141,12 @@ class EESSIBotSoftwareLayer(PyGHee):
                 comment_update += f" from `{sender}` (expanded command format: `{ebc.to_string()}`)"
             else:
                 self.log(f"'{line}' is not considered to contain a bot command")
-                # TODO keep the below for debugging purposes
-                comment_update += f"\n- line <code>{line}</code> is not considered to contain a bot command"
-                comment_update += "\n- bot commands begin with `bot: `, make sure"
-                comment_update += "\n  there is no whitespace at the beginning of a line"
+                # next three lines commented out to make the bot less noisy,
+                # could be enabled again if bot commands accept arg --verbose
+                # or bot instance has a similar setting
+                # comment_update += f"\n- line <code>{line}</code> is not considered to contain a bot command"
+                # comment_update += "\n- bot commands begin with `bot: `, make sure"
+                # comment_update += "\n  there is no whitespace at the beginning of a line"
         self.log(f"comment update: '{comment_update}'")
 
         if comment_update == '':
@@ -162,13 +167,22 @@ class EESSIBotSoftwareLayer(PyGHee):
         for cmd in commands:
             try:
                 update = self.handle_bot_command(event_info, cmd)
-                comment_update += f"\n- handling `{cmd.command}` resulted in: "
-                comment_update += update
-                update_pr_comment(event_info, comment_update)
+                # next two lines commented out to make the bot less noisy,
+                # could be enabled again if bot commands accept arg --verbose
+                # or bot instance has a similar setting; those were also a bit
+                # confusing when different instances overwrote comments of the
+                # other instances
+                # comment_update += f"\n- handling `{cmd.command}` resulted in: "
+                # comment_update += update
+                # update_pr_comment(event_info, comment_update)
+                self.log(f"handling '{cmd.command}' resulted in '{update}'")
             except EESSIBotCommandError as bce:
                 self.log(f"ERROR: handling {cmd.command} failed with {bce.args}")
-                comment_update += f"\n- handling `{cmd.command}` failed with {bce.args}"
-                update_pr_comment(event_info, comment_update)
+                # next two lines commented out to make the bot less noisy,
+                # could be enabled again if bot commands accept arg --verbose
+                # or bot instance has a similar setting
+                # comment_update += f"\n- handling `{cmd.command}` failed with {bce.args}"
+                # update_pr_comment(event_info, comment_update)
                 continue
             except Exception as err:
                 log(f"Unexpected err={err}, type(err)={type(err)}")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -64,7 +64,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         sender = request_body['sender']['login']
         owner = request_body['comment']['user']['login']
         txt = request_body['comment']['body']
-        self.log(f"Comment in {issue_url} {action} by @{sender} (owned by @{owner}): {txt}")
+        self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}: {txt}")
         # check if addition to comment includes a command for the bot, e.g.,
         #   bot: rebuild [arch:intel] [instance:AWS]
         #   bot: cancel [job:jobid]
@@ -96,7 +96,9 @@ class EESSIBotSoftwareLayer(PyGHee):
         # determine what is new in comment
         comment_diff = ''
         if action == 'created':
-            comment_diff = request_body['comment']['body']
+            comment_old = ''
+            comment_new = request_body['comment']['body']
+            comment_diff = comment_new[len(comment_old):]
             self.log(f"comment created: '{comment_diff}'")
         elif action == 'edited':
             comment_old = request_body['changes']['body']['from']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -96,6 +96,9 @@ class EESSIBotSoftwareLayer(PyGHee):
                 self.log(f"found bot command: '{match.group(1)}'")
                 comment_update += "\n- received bot command "
                 comment_update += f"`{match.group(1).rstrip()}`"
+                comment_update += f" from `{comment_author}`"
+            else:
+                self.log(f"`{line}` is not considered to contain a bot command")
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -84,7 +84,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: OLD '{comment_old}'")
             comment_new = request_body['comment']['body']
             self.log(f"comment edited: NEW '{comment_new}'")
-            comment_diff = comment_new.replace(comment_old, '')
+            comment_diff = comment_new[len(comment_old):]
             self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -74,19 +74,25 @@ class EESSIBotSoftwareLayer(PyGHee):
         #  - scan what's new for commands 'bot: COMMAND [ARGS*]'
         #  - process commands
         action = request_body['action']
+        self.log(f"comment action: {action}")
         comment_diff = ''
         if action == 'created':
             comment_diff = request_body['comment']['body']
+            self.log(f"comment created: '{comment_diff}'")
         elif action == 'edited':
             comment_old = request_body['changes']['body']['from']
             comment_new = request_body['comment']['body']
             comment_diff = comment_new.replace(comment_old, '')
+            self.log(f"comment edited: '{comment_diff}'")
         comment_update = ''
-        for new_line in comment_diff.split('\n'):
-            match = re.search('^bot: (.*)$', new_line)
+        for line in comment_diff.split('\n'):
+            self.log(f"searching line '{line}' for bot command")
+            match = re.search('^bot: (.*)$', line)
             if match:
+                self.log(f"found bot command: {match.group(1)}")
                 comment_update += "<hr/>\n received bot command "
                 comment_update += f"{match.group(1)}\n"
+        self.log(f"comment update: {comment_update}")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']
             pr_number = int(request_body['issue']['number'])

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -64,7 +64,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         sender = request_body['sender']['login']
         owner = request_body['comment']['user']['login']
         txt = request_body['comment']['body']
-        self.log("Comment in {issue_url} {action} by @{sender} (owned by @{owner}): {txt}")
+        self.log(f"Comment in {issue_url} {action} by @{sender} (owned by @{owner}): {txt}")
         # check if addition to comment includes a command for the bot, e.g.,
         #   bot: rebuild [arch:intel] [instance:AWS]
         #   bot: cancel [job:jobid]
@@ -124,9 +124,9 @@ class EESSIBotSoftwareLayer(PyGHee):
             else:
                 self.log(f"'{line}' is not considered to contain a bot command")
                 # TODO keep the below for debugging purposes
-                #comment_update += "\n- line <code>{line}</code> is not considered to contain a bot command"
-                #comment_update += "\n  bot commands begin with `bot: `, make sure"
-                #comment_update += "\n  there is no whitespace at the beginning of a line"
+                # comment_update += "\n- line <code>{line}</code> is not considered to contain a bot command"
+                # comment_update += "\n  bot commands begin with `bot: `, make sure"
+                # comment_update += "\n  there is no whitespace at the beginning of a line"
         self.log(f"comment update: '{comment_update}'")
         if comment_update == '':
             # no update to be added, just log and return

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -99,6 +99,9 @@ class EESSIBotSoftwareLayer(PyGHee):
                 comment_update += f" from `{comment_author}`"
             else:
                 self.log(f"`{line}` is not considered to contain a bot command")
+                comment_update += "\n- line `{line}` is not considered to contain a bot command"
+                comment_update += "\n  bot commands begin with `bot: `, make sure"
+                comment_update += "\n  there is no whitespace at the beginning of a line"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -76,9 +76,9 @@ class EESSIBotSoftwareLayer(PyGHee):
         action = request_body['action']
         comment_diff = ''
         if action == 'created':
-            comment_diff= request_body['comment']['body']
+            comment_diff = request_body['comment']['body']
         elif action == 'edited':
-            comment_old = request_body['changes']['body']['from'])
+            comment_old = request_body['changes']['body']['from']
             comment_new = request_body['comment']['body']
             comment_diff = comment_new.replace(comment_old, '')
         comment_update = ''

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -71,8 +71,11 @@ class EESSIBotSoftwareLayer(PyGHee):
         action = request_body['action']
         sender = request_body['sender']['login']
         owner = request_body['comment']['user']['login']
-        txt = request_body['comment']['body']
-        self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}: {txt}")
+        # next two lines are commented out and replaced to write less to log files
+        # txt = request_body['comment']['body']
+        # self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}: {txt}")
+        self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}")
+
         # check if addition to comment includes a command for the bot, e.g.,
         #   bot: build [arch:intel] [instance:AWS]
         #   bot: cancel [job:jobid]
@@ -106,7 +109,9 @@ class EESSIBotSoftwareLayer(PyGHee):
         # only scan for comments in newly created comments
         if action == 'created':
             comment_new = request_body['comment']['body']
-            self.log(f"comment created:\n########\n{comment_new.rstrip()}\n########")
+            # next line commented out and replaced to write less to log files
+            # self.log(f"comment created:\n########\n{comment_new.rstrip()}\n########")
+            self.log(f"comment action '{action}' is handled")
         else:
             self.log(f"comment action '{action}' not handled")
             return
@@ -117,10 +122,12 @@ class EESSIBotSoftwareLayer(PyGHee):
         comment_update = ''
         commands = []
         for line in comment_new.split('\n'):
-            self.log(f"searching line '{line}' for bot command")
+            # next line commented out to write less to log files
+            # self.log(f"searching line '{line}' for bot command")
             line_stripped = line.strip()
             if line.isspace() or len(line_stripped) == 0:
-                self.log(f"line '{line}' is empty")
+                # next line commented out to write less to log files
+                # self.log(f"line '{line}' is empty")
                 continue
             bot_command = get_bot_command(line)
             if bot_command:
@@ -139,20 +146,22 @@ class EESSIBotSoftwareLayer(PyGHee):
                 comment_update += "\n- received bot command "
                 comment_update += f"`{bot_command}`"
                 comment_update += f" from `{sender}` (expanded command format: `{ebc.to_string()}`)"
-            else:
-                self.log(f"'{line}' is not considered to contain a bot command")
+            # next two lines are commented out to write less to log files
+            # else:
+                # self.log(f"'{line}' is not considered to contain a bot command")
                 # next three lines commented out to make the bot less noisy,
                 # could be enabled again if bot commands accept arg --verbose
                 # or bot instance has a similar setting
                 # comment_update += f"\n- line <code>{line}</code> is not considered to contain a bot command"
                 # comment_update += "\n- bot commands begin with `bot: `, make sure"
                 # comment_update += "\n  there is no whitespace at the beginning of a line"
-        self.log(f"comment update: '{comment_update}'")
 
         if comment_update == '':
             # no update to be added, just log and return
             self.log("update to comment is empty")
             return
+        else:
+            self.log(f"comment update: '{comment_update}'")
 
         if not any(map(get_bot_command, comment_update.split('\n'))):
             # the 'not any()' ensures that the update would not be considered a bot command itself

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -19,21 +19,23 @@ import tasks.build as build
 import tasks.deploy as deploy
 
 from connections import github
+from tasks.build import check_build_permission, get_architecturetargets, get_repo_cfg, submit_build_jobs
+from tasks.deploy import deploy_built_artefacts
 from tools import config
 from tools.args import event_handler_parse
-from tools.commands import get_bot_command, EESSIBotCommand, EESSIBotCommandError
+from tools.commands import EESSIBotCommand, EESSIBotCommandError, get_bot_command
 from tools.filter import EESSIBotActionFilter
 from tools.permissions import check_command_permission
-from tools.pr_comments import update_pr_comment
-from tasks.build import check_build_permission, submit_build_jobs, get_repo_cfg, get_architecturetargets
-from tasks.deploy import deploy_built_artefacts
+from tools.pr_comments import create_comment
 
 from pyghee.lib import PyGHee, create_app, get_event_info, read_event_from_json
 from pyghee.utils import log
 
 
-GITHUB = "github"
 APP_NAME = "app_name"
+BOT_CONTROL = "bot_control"
+COMMAND_RESPONSE_FMT = "command_response_fmt"
+GITHUB = "github"
 REPO_TARGET_MAP = "repo_target_map"
 
 
@@ -72,29 +74,19 @@ class EESSIBotSoftwareLayer(PyGHee):
         action = request_body['action']
         sender = request_body['sender']['login']
         owner = request_body['comment']['user']['login']
-        # next two lines are commented out and replaced to write less to log files
-        # txt = request_body['comment']['body']
-        # self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}: {txt}")
+        # FIXME add request body text (['comment']['body']) to log message when
+        # log level is set to debug
         self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}")
 
-        # check if addition to comment includes a command for the bot, e.g.,
-        #   bot: build [arch:intel] [instance:AWS]
-        #   bot: cancel [job:jobid]
-        #   bot: disable [arch:generic]
-        # actions: created, edited
-        # created -> comment.body
-        # edited -> comment.body - changes.body.from
-        # procedure:
-        #  - determine what's new (assume new is at the end)
-        #  - scan what's new for commands 'bot: COMMAND [ARGS*]'
-        #  - process commands
+        # currently, only commands in new comments are supported
+        #  - commands have the syntax 'bot: COMMAND [ARGS*]'
 
         # first check if sender is authorized to send any command
-        # - double purpose:
+        # - this serves a double purpose:
         #   1. check permission
-        #   2. skip any comment updates that were done by the bot itself --> we
-        #      prevent the bot entering an endless loop where it reacts on
-        #      updates to comments it made itself
+        #   2. skip any comment updates that were done by the bot itself
+        #      --> thus we prevent the bot from entering an endless loop
+        #          where it reacts on updates to comments it made itself
         #      NOTE this assumes that the sender of the event is corresponding to
         #      the bot if the bot updates comments itself and that the bot is not
         #      given permission in the configuration setting 'command_permission'
@@ -107,100 +99,104 @@ class EESSIBotSoftwareLayer(PyGHee):
         else:
             self.log(f"account `{sender}` has permission to send commands to bot")
 
-        # only scan for comments in newly created comments
+        # only scan for commands in newly created comments
         if action == 'created':
-            comment_new = request_body['comment']['body']
-            # next line commented out and replaced to write less to log files
-            # self.log(f"comment created:\n########\n{comment_new.rstrip()}\n########")
+            comment_received = request_body['comment']['body']
             self.log(f"comment action '{action}' is handled")
         else:
             self.log(f"comment action '{action}' not handled")
             return
 
-        # search for commands in what is new in comment
-        # init comment_update with an empty string or later split would fail if
-        # it is None
-        comment_update = ''
+        # search for commands in comment
+        comment_response = ''
         commands = []
-        for line in comment_new.split('\n'):
-            # next line commented out to write less to log files
-            # self.log(f"searching line '{line}' for bot command")
-            line_stripped = line.strip()
-            if line.isspace() or len(line_stripped) == 0:
-                # next line commented out to write less to log files
-                # self.log(f"line '{line}' is empty")
-                continue
+        # process non-empty (if x) lines (split) in comment
+        for line in [x for x in [y.strip() for y in comment_received.split('\n')] if x]:
+            # FIXME add processed line(s) to log when log level is set to debug
             bot_command = get_bot_command(line)
             if bot_command:
                 try:
                     ebc = EESSIBotCommand(bot_command)
                 except EESSIBotCommandError as bce:
                     self.log(f"ERROR: parsing bot command '{bot_command}' failed with {bce.args}")
-                    # next two lines commented out to make the bot less noisy,
-                    # could be enabled again if bot commands accept arg --verbose
-                    # or bot instance has a similar setting
-                    # comment_update += f"\n- parsing bot command `{bot_command}` received"
-                    # comment_update += f" from sender `{sender}` failed"
+                    # FIXME possibly add more information to log when log level is set to debug
+                    comment_response += f"\n- parsing the bot command `{bot_command}`, received"
+                    comment_response += f" from sender `{sender}`, failed"
                     continue
                 commands.append(ebc)
                 self.log(f"found bot command: '{bot_command}'")
-                comment_update += "\n- received bot command "
-                comment_update += f"`{bot_command}`"
-                comment_update += f" from `{sender}` (expanded command format: `{ebc.to_string()}`)"
-            # next two lines are commented out to write less to log files
-            # else:
-                # self.log(f"'{line}' is not considered to contain a bot command")
-                # next three lines commented out to make the bot less noisy,
-                # could be enabled again if bot commands accept arg --verbose
-                # or bot instance has a similar setting
-                # comment_update += f"\n- line <code>{line}</code> is not considered to contain a bot command"
-                # comment_update += "\n- bot commands begin with `bot: `, make sure"
-                # comment_update += "\n  there is no whitespace at the beginning of a line"
+                comment_response += "\n- received bot command `{bot_command}`"
+                comment_response += f" from `{sender}`"
+                comment_response += f"\n  - expanded format: `{ebc.to_string()}`"
+            # FIXME add an else branch that logs information for comments not
+            # including a bot command; the logging should only be done when log
+            # level is set to debug
 
-        if comment_update == '':
+        if comment_response == '':
             # no update to be added, just log and return
-            self.log("update to comment is empty")
+            self.log("comment response is empty")
             return
         else:
-            self.log(f"comment update: '{comment_update}'")
+            self.log(f"comment response: '{comment_response}'")
 
-        if not any(map(get_bot_command, comment_update.split('\n'))):
-            # the 'not any()' ensures that the update would not be considered a bot command itself
+        # obtain app name and format for reporting about received & processed
+        # commands
+        app_name = self.cfg[GITHUB][APP_NAME]
+        command_response_fmt = self.cfg[BOT_CONTROL][COMMAND_RESPONSE_FMT]
+
+        if not any(map(get_bot_command, comment_response.split('\n'))):
+            # the 'not any()' ensures that the response would not be considered a bot command itself
             # ... together with checking the sender of a comment update this aims
             # at preventing the bot to enter an endless loop in commenting on its own
             # comments
-            update_pr_comment(event_info, comment_update)
+            repo_name = request_body['repository']['full_name']
+            pr_number = request_body['issue']['number']
+            comment_body = command_response_fmt.format(
+                app_name=app_name,
+                comment_response=comment_response,
+                comment_result=''
+            )
+            issue_comment = create_comment(repo_name, pr_number, comment_body)
         else:
-            self.log(f"update '{comment_update}' is considered to contain bot command ... not updating PR comment")
+            self.log(f"update '{comment_response}' is considered to contain bot command ... not creating PR comment")
+            # FIXME we may want to report this back to the PR on GitHub, e.g.,
+            # "Oops response message seems to contain a bot command. It is not
+            # displayed here to prevent the bot from entering an endless loop
+            # of commands. Please, check the logs at the bot instance for more
+            # information."
 
         # process commands
+        comment_result = ''
         for cmd in commands:
             try:
                 update = self.handle_bot_command(event_info, cmd)
-                # the update to the PR comment is only done if the command is
-                # 'help'; otherwise there was too much noise and also updates
-                # were a bit confusing when different instances overwrote
-                # comments of the other instances
-                if cmd.command == 'help':
-                    comment_update += f"\n- handling `{cmd.command}` resulted in: "
-                    comment_update += update
-                    update_pr_comment(event_info, comment_update)
-
+                comment_result += f"\n- handling `{cmd.command}` resulted in: "
+                comment_result += update
                 self.log(f"handling '{cmd.command}' resulted in '{update}'")
 
             except EESSIBotCommandError as bce:
                 self.log(f"ERROR: handling {cmd.command} failed with {bce.args}")
-                # next two lines commented out to make the bot less noisy,
-                # could be enabled again if bot commands accept arg --verbose
-                # or bot instance has a similar setting
-                # comment_update += f"\n- handling `{cmd.command}` failed with {bce.args}"
-                # update_pr_comment(event_info, comment_update)
+                comment_result += f"\n- handling `{cmd.command}` failed with {bce.args}"
                 continue
             except Exception as err:
                 log(f"Unexpected err={err}, type(err)={type(err)}")
+                if comment_result:
+                    comment_body = command_response_fmt.format(
+                        app_name=app_name,
+                        comment_response=comment_response,
+                        comment_result=comment_result
+                    )
+                    issue_comment.edit(comment_body)
                 raise
+        # only update PR comment once
+        comment_body = command_response_fmt.format(
+            app_name=app_name,
+            comment_response=comment_response,
+            comment_result=comment_result
+        )
+        issue_comment.edit(comment_body)
 
-        self.log("issue_comment event handled!")
+        self.log(f"issue_comment event (url {issue_url}) handled!")
 
     def handle_installation_event(self, event_info, log_file=None):
         """
@@ -303,14 +299,16 @@ class EESSIBotSoftwareLayer(PyGHee):
             raise EESSIBotCommandError(f"unknown command '{cmd}'; use `bot: help` for usage information")
 
     def handle_bot_command_help(self, event_info, bot_command):
+        """handles command 'bot: help' with a simple usage info"""
         help_msg = "\n  **How to send commands to bot instances**"
         help_msg += "\n  - Commands must be sent with a **new** comment (edits of existing comments are ignored)."
         help_msg += "\n  - A comment may contain multiple commands, one per line."
         help_msg += "\n  - Every command begins at the start of a line and has the syntax `bot: COMMAND [ARGUMENTS]*`"
-        help_msg += "\n  - Currently supported COMMANDs are: `help`, `build`, `showconfig`"
+        help_msg += "\n  - Currently supported COMMANDs are: `help`, `build`, `show_config`"
         return help_msg
 
     def handle_bot_command_build(self, event_info, bot_command):
+        """handles command 'bot: build [ARGS*]' by parsing arguments and submitting jobs"""
         gh = github.get_instance()
         self.log("repository: '%s'", event_info['raw_request_body']['repository']['full_name'])
         repo_name = event_info['raw_request_body']['repository']['full_name']
@@ -326,23 +324,9 @@ class EESSIBotSoftwareLayer(PyGHee):
             build_msg = f"account {sender} has no permission to submit build jobs"
         return build_msg
 
-#    def handle_bot_command_deploy(self, event_info, bot_command):
-#        return
-
-#    def handle_bot_command_enable(self, event_info, bot_command):
-#        return
-
-#    def handle_bot_command_disable(self, event_info, bot_command):
-#        return
-
-#    def handle_bot_command_cancel(self, event_info, bot_command):
-#        return
-
-#    def handle_bot_command_status(self, event_info, bot_command):
-#        return
-
-    def handle_bot_command_showconfig(self, event_info, bot_command):
-        self.log("processing bot command 'showconfig'")
+    def handle_bot_command_show_config(self, event_info, bot_command):
+        """handles command 'bot: show_config' by printing a list of configured build targets"""
+        self.log("processing bot command 'show_config'")
         gh = github.get_instance()
         repo_name = event_info['raw_request_body']['repository']['full_name']
         pr_number = event_info['raw_request_body']['issue']['number']

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -354,6 +354,10 @@ def prepare_jobs(pr, event_dir, build_env_cfg, arch_map, repocfg):
             if repo_id != "EESSI-pilot" and repo_id not in repocfg:
                 log(f"{fn}(): skipping repo {repo_id}, it is not defined in repo config {repocfg[REPOS_CFG_DIR]}")
                 continue
+
+            # TODO check filter: context = (arch, repo, app_name)
+            #      passed --> log & go on
+            #      missed --> log & continue
             job_dir = os.path.join(event_dir, arch_dir, repo_id)
             os.makedirs(job_dir, exist_ok=True)
             log(f"{fn}(): job_dir '{job_dir}'")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -397,7 +397,7 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
             #   false --> log & continue
             if action_filter:
                 log(f"{fn}(): checking filter {action_filter.to_string()}")
-                context = {{"architecture": arch}, {"repository": repo_id}, {"instance": app_name}}
+                context = {"architecture": arch, "repository": repo_id, "instance": app_name}
                 log(f"{fn}(): context is '{json.dumps(context, indent=4)}'")
                 if not action_filter.check_filters(context):
                     log(f"{fn}(): context does NOT satisfy filter(s), skipping")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -319,13 +319,13 @@ def apply_cvmfs_customizations(cvmfs_customizations, arch_job_dir):
             #      for now, only existing mappings may be customized
 
 
-def prepare_jobs(pr, event_dir, build_env_cfg, arch_map, repocfg):
+def prepare_jobs(pr, run_dir, build_env_cfg, arch_map, repocfg):
     """prepare job directory with pull request and cfg/job.cfg as well as
        additional config files
 
     Args:
         pr: github.PullRequest.Pullrequest object
-        event_dir: base directory for all jobs created for this event
+        run_dir: base directory for all jobs created for this event
         build_env_cfg: build env configuration
         arch_map: maps OS/SW_DIR to Slurm parameters
         repocfg: repository config
@@ -358,7 +358,10 @@ def prepare_jobs(pr, event_dir, build_env_cfg, arch_map, repocfg):
             # TODO check filter: context = (arch, repo, app_name)
             #      passed --> log & go on
             #      missed --> log & continue
-            job_dir = os.path.join(event_dir, arch_dir, repo_id)
+            # what is the state of the job, directory tree at this point? can we defer some to after we have checked the filter?
+            # - list functions called from eessi_bot_event_handler.py to here and what they do (changes on disk, data structures, calls to GH, ...)
+            # - determine if and how those need and can be deferred
+            job_dir = os.path.join(run_dir, arch_dir, repo_id)
             os.makedirs(job_dir, exist_ok=True)
             log(f"{fn}(): job_dir '{job_dir}'")
 

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -117,7 +117,7 @@ def get_build_env_cfg(cfg):
     cvmfs_customizations = {}
     try:
         cvmfs_customizations_str = buildenv.get(CVMFS_CUSTOMIZATIONS)
-        log("cvmfs_customizations '{cvmfs_customizations_str}'")
+        log("{fn}(): cvmfs_customizations '{cvmfs_customizations_str}'")
 
         if cvmfs_customizations_str is not None:
             cvmfs_customizations = json.loads(cvmfs_customizations_str)
@@ -144,8 +144,8 @@ def get_build_env_cfg(cfg):
     return config_data
 
 
-def get_architecturetargets(cfg):
-    """get architecturetargets and set arch_target_map
+def get_architecture_targets(cfg):
+    """get architecture_targets and set arch_target_map
 
     Args:
         cfg (dict): dictionary holding full configuration (by default defined in app.cfg)
@@ -157,9 +157,9 @@ def get_architecturetargets(cfg):
     fn = sys._getframe().f_code.co_name
 
     # cfg = config.read_config()
-    architecturetargets = cfg[ARCHITECTURE_TARGETS]
+    architecture_targets = cfg[ARCHITECTURE_TARGETS]
 
-    arch_target_map = json.loads(architecturetargets.get('arch_target_map'))
+    arch_target_map = json.loads(architecture_targets.get('arch_target_map'))
     log(f"{fn}(): arch target map '{json.dumps(arch_target_map)}'")
     return arch_target_map
 
@@ -255,7 +255,7 @@ def create_pr_dir(pr, cfg, event_info):
     Returns:
         tuple of 3 elements containing
 
-        - ym (string): string with datestamp (<year>.<month>)
+        - year_month (string): string with datestamp (<year>.<month>)
         - pr_id (int): pr number
         - run_dir (string): path to run_dir
     """
@@ -268,10 +268,10 @@ def create_pr_dir(pr, cfg, event_info):
     build_env_cfg = get_build_env_cfg(cfg)
     jobs_base_dir = build_env_cfg[JOBS_BASE_DIR]
 
-    ym = datetime.today().strftime('%Y.%m')
+    year_month = datetime.today().strftime('%Y.%m')
     pr_id = 'pr_%s' % pr.number
     event_id = 'event_%s' % event_info['id']
-    event_dir = os.path.join(jobs_base_dir, ym, pr_id, event_id)
+    event_dir = os.path.join(jobs_base_dir, year_month, pr_id, event_id)
     # the makedirs cannot be deferred to a later os.makedirs because the
     # condition in the while loop below takes the state of the directory
     # contents into account
@@ -283,7 +283,7 @@ def create_pr_dir(pr, cfg, event_info):
     run_dir = os.path.join(event_dir, 'run_%03d' % run)
     os.makedirs(run_dir, exist_ok=True)
 
-    return ym, pr_id, run_dir
+    return year_month, pr_id, run_dir
 
 
 def download_pr(repo_name, branch_name, pr, arch_job_dir):
@@ -357,7 +357,7 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
         pr (github.PullRequest.Pullrequest): object to interact with pull request
         cfg (dict): dictionary holding full configuration (by default defined in app.cfg)
         event_info (dict): event received by event_handler
-        action_filter (EESSIBotActionFilter): used to filter which jobs shall be prepared
+        action_filter (EESSIBotActionFilter instance): used to filter which jobs shall be prepared
 
     Returns:
         jobs: list of the created jobs
@@ -366,7 +366,7 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
 
     app_name = cfg[GITHUB].get(APP_NAME)
     build_env_cfg = get_build_env_cfg(cfg)
-    arch_map = get_architecturetargets(cfg)
+    arch_map = get_architecture_targets(cfg)
     repocfg = get_repo_cfg(cfg)
 
     base_repo_name = pr.base.repo.full_name
@@ -381,7 +381,7 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
     # instead of using a run_dir, maybe just create a unique dir for each
     # job to be submitted? thus we could easily postpone the create_pr_dir
     # call to just before download_pr
-    ym, pr_id, run_dir = create_pr_dir(pr, cfg, event_info)
+    year_month, pr_id, run_dir = create_pr_dir(pr, cfg, event_info)
 
     jobs = []
     for arch, slurm_opt in arch_map.items():
@@ -398,8 +398,8 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
                 continue
 
             # if filter exists, check filter against context = (arch, repo, app_name)
-            #   true --> log & go on
-            #   false --> log & continue
+            #   true --> log & go on in this iteration of for loop
+            #   false --> log & continue to next iteration of for loop
             if action_filter:
                 log(f"{fn}(): checking filter {action_filter.to_string()}")
                 context = {"architecture": arch, "repository": repo_id, "instance": app_name}
@@ -423,7 +423,7 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
             prepare_job_cfg(job_dir, build_env_cfg, repocfg, repo_id, cpu_target, os_type)
 
             # enlist jobs to proceed
-            job = Job(job_dir, arch, repo_id, slurm_opt, ym, pr_id)
+            job = Job(job_dir, arch, repo_id, slurm_opt, year_month, pr_id)
             jobs.append(job)
 
     log(f"{fn}(): {len(jobs)} jobs to proceed after applying white list")
@@ -562,10 +562,8 @@ def submit_job(job, cfg):
     log(f"{fn}(): sbatch err: {cmdline_error}")
 
     job_id = cmdline_output.split()[3]
-    ym = job.year_month
-    pr_id = job.pr_id
 
-    symlink = os.path.join(build_env_cfg[JOBS_BASE_DIR], ym, pr_id, job_id)
+    symlink = os.path.join(build_env_cfg[JOBS_BASE_DIR], job.year_month, job.pr_id, job_id)
     log(f"{fn}(): create symlink {symlink} -> {job[0]}")
     os.symlink(job[0], symlink)
 
@@ -645,9 +643,9 @@ def submit_build_jobs(pr, event_info, action_filter):
        running jobs and adding comments
 
     Args:
-        pr (github.PullRequest.Pullrequest): object to interact with pull request
+        pr (github.PullRequest.Pullrequest instance): object to interact with pull request
         event_info (string): event received by event_handler
-        action_filter (EESSIBotActionFilter): used to filter which jobs shall be prepared
+        action_filter (EESSIBotActionFilter instance): used to filter which jobs shall be prepared
     """
     fn = sys._getframe().f_code.co_name
 
@@ -663,7 +661,7 @@ def submit_build_jobs(pr, event_info, action_filter):
         log(f"{fn}(): no jobs ({len(jobs)}) to be submitted")
         return "no jobs were prepared"
 
-    # obtain handle to GH
+    # obtain handle to GitHub
     gh = github.get_instance()
 
     # process prepared jobs: submit, create metadata file and add comment to PR
@@ -679,8 +677,7 @@ def submit_build_jobs(pr, event_info, action_filter):
         # create _bot_job<jobid>.metadata file in submission directory
         create_metadata_file(job, job_id, pr, pr_comment_id)
 
-    return_msg = f"created jobs: {', '.join(job_ids)}"
-    return return_msg
+    return f"created jobs: {', '.join(job_ids)}"
 
 
 def check_build_permission(pr, event_info):

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -45,7 +45,8 @@ def determine_job_dirs(pr_number):
     #  - we may have to scan multiple YYYY.MM directories if the PR was
     #    processed over more than one month
     #  - we assume that job IDs are positive integer numbers
-    build_env_cfg = get_build_env_cfg()
+    cfg = config.read_config()
+    build_env_cfg = get_build_env_cfg(cfg)
     jobs_base_dir = build_env_cfg[JOBS_BASE_DIR]
     log(f"{funcname}(): jobs_base_dir = {jobs_base_dir}")
 

--- a/tests/test_app.cfg
+++ b/tests/test_app.cfg
@@ -4,21 +4,21 @@
 
 # variable 'comment' under 'submitted_job_comments' should not be changed as there are regular expression patterns matching it
 [submitted_job_comments]
-initial_comment = New job on instance `{app_name}` for architecture `{arch_name}` for repository `{repo_id}` in job dir `{symlink}` 
-awaits_release = job id `{job_id}` awaits release by job manager 
+initial_comment = New job on instance `{app_name}` for architecture `{arch_name}` for repository `{repo_id}` in job dir `{symlink}`
+awaits_release = job id `{job_id}` awaits release by job manager
 
 [new_job_comments]
-awaits_lauch = job awaits launch by Slurm scheduler 
+awaits_lauch = job awaits launch by Slurm scheduler
 
 [running_job_comments]
-running_job = job `{job_id}` is running 
+running_job = job `{job_id}` is running
 
 [finished_job_comments]
-success = :grin: SUCCESS tarball `{tarball_name}` ({tarball_size} GiB) in job dir 
-failure = :cry: FAILURE 
-no_slurm_out = No slurm output `{slurm_out}` in job dir 
-slurm_out = Found slurm output `{slurm_out}` in job dir 
-missing_modules = Slurm output lacks message "No missing modules!". 
-no_tarball_message = Slurm output lacks message about created tarball. 
-no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir. 
-multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected. 
+success = :grin: SUCCESS tarball `{tarball_name}` ({tarball_size} GiB) in job dir
+failure = :cry: FAILURE
+no_slurm_out = No slurm output `{slurm_out}` in job dir
+slurm_out = Found slurm output `{slurm_out}` in job dir
+missing_modules = Slurm output lacks message "No missing modules!".
+no_tarball_message = Slurm output lacks message about created tarball.
+no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir.
+multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected.

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -178,7 +178,7 @@ class MockRepository:
 
 class MockPullRequest:
     def __init__(self, pr_number, create_raises='0', create_exception=Exception, create_fails=False):
-        self.pr_number = pr_number
+        self.number = pr_number
         self.issue_comments = []
         self.create_fails = create_fails
         self.create_raises = create_raises

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -154,8 +154,12 @@ class MockGitHub:
         repo = self.repos[repo_name]
         return repo
 
+
 MockBase = namedtuple('MockBase', ['repo'])
+
+
 MockRepo = namedtuple('MockRepo', ['full_name'])
+
 
 class MockRepository:
     def __init__(self, repo_name):

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -116,10 +116,10 @@ class CreateIssueCommentException(Exception):
 
 # cases for testing create_pr_comment (essentially testing create_issue_comment)
 # - create_issue_comment succeeds immediately
-#   - returns !None --> create_pr_comment returns comment (with comment_id == 1)
+#   - returns !None --> create_pr_comment returns comment (with id == 1)
 #   - returns None --> create_pr_comment returns None
 # - create_issue_comment fails once, then succeeds
-#   - returns !None --> create_pr_comment returns comment (with comment_id == 1)
+#   - returns !None --> create_pr_comment returns comment (with id == 1)
 # - create_issue_comment always fails
 # - create_issue_comment fails 3 times
 #   - symptoms of failure: exception raised or return value of tested func None
@@ -269,7 +269,7 @@ def mocked_github(request):
 
 
 # case 1: create_issue_comment succeeds immediately
-#         returns !None --> create_pr_comment returns comment (with comment_id == 1)
+#         returns !None --> create_pr_comment returns comment (with id == 1)
 @pytest.mark.repo_name("EESSI/software-layer")
 @pytest.mark.pr_number(1)
 def test_create_pr_comment_succeeds(mocked_github, tmpdir):
@@ -289,7 +289,7 @@ def test_create_pr_comment_succeeds(mocked_github, tmpdir):
     pr = repo.get_pull(pr_number)
     symlink = "/symlink"
     comment = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
-    assert comment.comment_id == 1
+    assert comment.id == 1
     # check if created comment includes jobid?
     print("VERIFYING PR COMMENT")
     comment = get_submitted_job_comment(pr, job_id)
@@ -322,7 +322,7 @@ def test_create_pr_comment_succeeds_none(mocked_github, tmpdir):
 
 
 # case 3: create_issue_comment fails once, then succeeds
-#         returns !None --> create_pr_comment returns comment (with comment_id == 1)
+#         returns !None --> create_pr_comment returns comment (with id == 1)
 @pytest.mark.repo_name("EESSI/software-layer")
 @pytest.mark.pr_number(1)
 @pytest.mark.create_raises("1")
@@ -343,7 +343,7 @@ def test_create_pr_comment_raises_once_then_succeeds(mocked_github, tmpdir):
     pr = repo.get_pull(pr_number)
     symlink = "/symlink"
     comment = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
-    assert comment.comment_id == 1
+    assert comment.id == 1
     assert pr.create_call_count == 2
 
 

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -20,6 +20,7 @@ import shutil
 from unittest.mock import patch
 
 # Third party imports (anything installed into the local Python environment)
+from collections import namedtuple
 from datetime import datetime
 import pytest
 
@@ -153,6 +154,8 @@ class MockGitHub:
         repo = self.repos[repo_name]
         return repo
 
+MockBase = namedtuple('MockBase', ['repo'])
+MockRepo = namedtuple('MockRepo', ['full_name'])
 
 class MockRepository:
     def __init__(self, repo_name):
@@ -165,6 +168,7 @@ class MockRepository:
         else:
             self.pull_requests[pr_number] = MockPullRequest(pr_number, create_raises,
                                                             CreateIssueCommentException, create_fails)
+            self.pull_requests[pr_number].base = MockBase(MockRepo(self.repo_name))
             return self.pull_requests[pr_number]
 
     def get_pull(self, pr_number):

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -116,13 +116,13 @@ class CreateIssueCommentException(Exception):
 
 # cases for testing create_pr_comment (essentially testing create_issue_comment)
 # - create_issue_comment succeeds immediately
-#   - returns !None --> create_pr_comment returns 1
-#   - returns None --> create_pr_comment returns -1
+#   - returns !None --> create_pr_comment returns comment (with comment_id == 1)
+#   - returns None --> create_pr_comment returns None
 # - create_issue_comment fails once, then succeeds
-#   - returns !None --> create_pr_comment returns 1
+#   - returns !None --> create_pr_comment returns comment (with comment_id == 1)
 # - create_issue_comment always fails
 # - create_issue_comment fails 3 times
-#   - symptoms of failure: exception raised or return value of tested func -1
+#   - symptoms of failure: exception raised or return value of tested func None
 
 # overall course of creating mocked objects
 # patch gh.get_repo(repo_name) --> returns a MockRepository
@@ -269,7 +269,7 @@ def mocked_github(request):
 
 
 # case 1: create_issue_comment succeeds immediately
-#         returns !None --> create_pr_comment returns 1
+#         returns !None --> create_pr_comment returns comment (with comment_id == 1)
 @pytest.mark.repo_name("EESSI/software-layer")
 @pytest.mark.pr_number(1)
 def test_create_pr_comment_succeeds(mocked_github, tmpdir):
@@ -288,8 +288,8 @@ def test_create_pr_comment_succeeds(mocked_github, tmpdir):
     repo = mocked_github.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
     symlink = "/symlink"
-    comment_id = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
-    assert comment_id == 1
+    comment = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
+    assert comment.comment_id == 1
     # check if created comment includes jobid?
     print("VERIFYING PR COMMENT")
     comment = get_submitted_job_comment(pr, job_id)
@@ -297,7 +297,7 @@ def test_create_pr_comment_succeeds(mocked_github, tmpdir):
 
 
 # case 2: create_issue_comment succeeds immediately
-#         returns None --> create_pr_comment returns -1
+#         returns None --> create_pr_comment returns None
 @pytest.mark.repo_name("EESSI/software-layer")
 @pytest.mark.pr_number(1)
 @pytest.mark.create_fails(True)
@@ -317,12 +317,12 @@ def test_create_pr_comment_succeeds_none(mocked_github, tmpdir):
     repo = mocked_github.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
     symlink = "/symlink"
-    comment_id = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
-    assert comment_id == -1
+    comment = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
+    assert comment is None
 
 
 # case 3: create_issue_comment fails once, then succeeds
-#         returns !None --> create_pr_comment returns 1
+#         returns !None --> create_pr_comment returns comment (with comment_id == 1)
 @pytest.mark.repo_name("EESSI/software-layer")
 @pytest.mark.pr_number(1)
 @pytest.mark.create_raises("1")
@@ -342,8 +342,8 @@ def test_create_pr_comment_raises_once_then_succeeds(mocked_github, tmpdir):
     repo = mocked_github.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
     symlink = "/symlink"
-    comment_id = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
-    assert comment_id == 1
+    comment = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
+    assert comment.comment_id == 1
     assert pr.create_call_count == 2
 
 

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -180,6 +180,7 @@ class MockPullRequest:
         self.create_raises = create_raises
         self.create_exception = create_exception
         self.create_call_count = 0
+        self.base = None
 
     def create_issue_comment(self, body):
         def should_raise_exception():

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -20,6 +20,7 @@ import shutil
 from unittest.mock import patch
 
 # Third party imports (anything installed into the local Python environment)
+from datetime import datetime
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
@@ -267,18 +268,21 @@ def test_create_pr_comment_succeeds(mocked_github, tmpdir):
     shutil.copyfile("tests/test_app.cfg", "app.cfg")
     # creating a PR comment
     print("CREATING PR COMMENT")
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up")
+    ym = datetime.today().strftime('%Y.%m')
+    pr_number = 1
+    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up", ym, pr_number)
+
     job_id = "123"
     app_name = "pytest"
-    pr_number = 1
+
     repo_name = "EESSI/software-layer"
+    repo = mocked_github.get_repo(repo_name)
+    pr = repo.get_pull(pr_number)
     symlink = "/symlink"
-    comment_id = create_pr_comment(job, job_id, app_name, pr_number, repo_name, mocked_github, symlink)
+    comment_id = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
     assert comment_id == 1
     # check if created comment includes jobid?
     print("VERIFYING PR COMMENT")
-    repo = mocked_github.get_repo(repo_name)
-    pr = repo.get_pull(pr_number)
     comment = get_submitted_job_comment(pr, job_id)
     assert job_id in comment.body
 

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -10,7 +10,6 @@
 #
 
 # Standard library imports
-import json
 
 # Third party imports (anything installed into the local Python environment)
 import pytest
@@ -89,9 +88,9 @@ def complex_filter():
 
 
 def test_create_complex_filter(complex_filter):
-    expected = f"architecture:.*intel.*\n"
-    expected += f"repository:nessi.no-2022.*\n"
-    expected += f"instance:[aA]\n"
+    expected = "architecture:.*intel.*\n"
+    expected += "repository:nessi.no-2022.*\n"
+    expected += "instance:[aA]\n"
     actual = complex_filter.to_string()
     assert expected == actual
 

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -30,7 +30,7 @@ def test_add_single_action_filter():
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
-    expected = "architecture:.*intel.*\n"
+    expected = "architecture:.*intel.*"
     actual = af.to_string()
     assert expected == actual
 
@@ -62,7 +62,7 @@ def test_check_matching_simple_filter():
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
-    expected = f"architecture:{pattern}\n"
+    expected = f"architecture:{pattern}"
     actual = af.to_string()
     assert expected == actual
 
@@ -88,9 +88,9 @@ def complex_filter():
 
 
 def test_create_complex_filter(complex_filter):
-    expected = "architecture:.*intel.*\n"
-    expected += "repository:nessi.no-2022.*\n"
-    expected += "instance:[aA]\n"
+    expected = "architecture:.*intel.*"
+    expected += " repository:nessi.no-2022.*"
+    expected += " instance:[aA]"
     actual = complex_filter.to_string()
     assert expected == actual
 

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -19,14 +19,14 @@ from tools.filter import EESSIBotActionFilter
 
 
 def test_empty_action_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     expected = ''
     actual = af.to_string()
     assert expected == actual
 
 
 def test_add_single_action_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
@@ -36,7 +36,7 @@ def test_add_single_action_filter():
 
 
 def test_add_non_supported_component():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component = 'machine'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
@@ -46,7 +46,7 @@ def test_add_non_supported_component():
 
 
 def test_check_matching_empty_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     expected = ''
     actual = af.to_string()
     assert expected == actual
@@ -58,7 +58,7 @@ def test_check_matching_empty_filter():
 
 
 def test_check_matching_simple_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
@@ -74,7 +74,7 @@ def test_check_matching_simple_filter():
 
 @pytest.fixture
 def complex_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component1 = 'arch'
     pattern1 = '.*intel.*'
     af.add_filter(component1, pattern1)
@@ -125,7 +125,7 @@ def test_non_match_architecture_repository_context(complex_filter):
 
 @pytest.fixture
 def arch_filter_slash_syntax():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component1 = 'arch'
     pattern1 = '.*/intel/.*'
     af.add_filter(component1, pattern1)
@@ -146,7 +146,7 @@ def test_match_architecture_syntax_slash(arch_filter_slash_syntax):
 
 @pytest.fixture
 def arch_filter_dash_syntax():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component1 = 'arch'
     pattern1 = '.*-intel-.*'
     af.add_filter(component1, pattern1)

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -15,7 +15,7 @@
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from tools.filter import EESSIBotActionFilter
+from tools.filter import EESSIBotActionFilter, EESSIBotActionFilterError
 
 
 def test_empty_action_filter():
@@ -39,10 +39,9 @@ def test_add_non_supported_component():
     af = EESSIBotActionFilter("")
     component = 'machine'
     pattern = '.*intel.*'
-    af.add_filter(component, pattern)
-    expected = ''
-    actual = af.to_string()
-    assert expected == actual
+    with pytest.raises(Exception) as err:
+        af.add_filter(component, pattern)
+    assert err.type == EESSIBotActionFilterError
 
 
 def test_check_matching_empty_filter():

--- a/tests/test_tools_pr_comments.py
+++ b/tests/test_tools_pr_comments.py
@@ -29,7 +29,7 @@ class MockIssueComment:
         self.edit_raises = edit_raises
         self.edit_exception = edit_exception
         self.edit_call_count = 0
-        self.id = 1
+        self.comment_id = 1
 
     def edit(self, body):
         def should_raise_exception():

--- a/tests/test_tools_pr_comments.py
+++ b/tests/test_tools_pr_comments.py
@@ -29,7 +29,7 @@ class MockIssueComment:
         self.edit_raises = edit_raises
         self.edit_exception = edit_exception
         self.edit_call_count = 0
-        self.comment_id = 1
+        self.id = 1
 
     def edit(self, body):
         def should_raise_exception():

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -58,4 +58,5 @@ class EESSIBotCommand:
             self.action_filters = EESSIBotActionFilter("")
 
     def to_string(self):
-        return f"{self.command} {self.action_filters.to_string()}"
+        action_filters_str = self.action_filters.to_string()
+        return f"{' '.join([self.command, action_filters_str]}"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -63,4 +63,4 @@ class EESSIBotCommand:
 
     def to_string(self):
         action_filters_str = self.action_filters.to_string()
-        return f"{' '.join([self.command, action_filters_str])}"
+        return f"{' '.join([self.command, action_filters_str]).rstrip()}"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -59,4 +59,4 @@ class EESSIBotCommand:
 
     def to_string(self):
         action_filters_str = self.action_filters.to_string()
-        return f"{' '.join([self.command, action_filters_str]}"
+        return f"{' '.join([self.command, action_filters_str])}"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -39,6 +39,11 @@ class EESSIBotCommandError(Exception):
 
 
 class EESSIBotCommand:
+    """
+    Class for representing a bot command which includes the command itself and
+    a filter to limit for which architecture, repository and bot instance the
+    command should be applied to.
+    """
     def __init__(self, cmd_str):
         cmd_as_list = cmd_str.split()
         self.command = cmd_as_list[0]
@@ -46,9 +51,8 @@ class EESSIBotCommand:
             arg_str = " ".join(cmd_as_list[1:])
             try:
                 self.action_filters = EESSIBotActionFilter(arg_str)
-            except EESSIBotActionFilterError as baf:
-                reason = baf.args
-                log(f"ERROR: EESSIBotActionFilterError - {reason}")
+            except EESSIBotActionFilterError as err:
+                log(f"ERROR: EESSIBotActionFilterError - {err.args}")
                 self.action_filters = None
                 raise EESSIBotCommandError("invalid action filter")
             except Exception as err:

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -12,7 +12,7 @@ import re
 import sys
 
 from pyghee.utils import log
-from tools.filter import Filter, EESSIBotActionFilter, EESSIBotActionFilterError
+from tools.filter import EESSIBotActionFilter, EESSIBotActionFilterError
 
 
 def get_bot_command(line):
@@ -49,13 +49,13 @@ class EESSIBotCommand:
             except EESSIBotActionFilterError as baf:
                 reason = baf.args
                 log(f"ERROR: EESSIBotActionFilterError - {reason}")
-                self.action_filters = []
+                self.action_filters = None
                 raise EESSIBotCommandError("invalid action filter")
             except Exception as err:
                 log(f"Unexpected {err=}, {type(err)=}")
                 raise
         else:
-            self.action_filters = []
+            self.action_filters = EESSIBotActionFilter("")
 
     def to_string(self):
         return f"{self.command} {self.action_filters.to_string()}"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -52,7 +52,7 @@ class EESSIBotCommand:
                 self.action_filters = None
                 raise EESSIBotCommandError("invalid action filter")
             except Exception as err:
-                log(f"Unexpected {err=}, {type(err)=}")
+                log(f"Unexpected err={err}, type(err)={type(err)}")
                 raise
         else:
             self.action_filters = EESSIBotActionFilter("")

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -1,0 +1,33 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+import re
+import sys
+
+from pyghee.utils import log
+
+
+def get_bot_command(line):
+    """
+        Retrieve bot command from a line.
+    Args:
+        line (string): string that is scanned for a command
+
+    Returns:
+        command (string): the command if any found or None
+    """
+    fn = sys._getframe().f_code.co_name
+
+    log(f"{fn}(): searching for bot command in '{line}'")
+    match = re.search('^bot: (.*)$', line)
+    if match:
+        return match.group(1).rstrip()
+    else:
+        return None

--- a/tools/filter.py
+++ b/tools/filter.py
@@ -38,7 +38,7 @@ class EESSIBotActionFilter:
             except EESSIBotActionFilterError:
                 raise
             except Exception as err:
-                log(f"Unexpected {err=}, {type(err)=}")
+                log(f"Unexpected err={err}, type(err)={type(err)}")
                 raise
 
     def clear_all(self):
@@ -66,7 +66,7 @@ class EESSIBotActionFilter:
             self.action_filters.append(Filter(full_component, pattern))
         else:
             log(f"component {component} is unknown")
-            raise EESSIBotActionFilterError(f"unknown {component=} in {component}:{pattern}")
+            raise EESSIBotActionFilterError(f"unknown component={component} in {component}:{pattern}")
 
     def add_filter_from_string(self, filter_string):
         """

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -18,7 +18,7 @@ COMMAND_PERMISSION = "command_permission"
 
 
 def check_command_permission(account):
-    """check if the GH account is authorized to send commands to the bot
+    """check if the GitHub account is authorized to send commands to the bot
 
     Args:
         account (string): account for which permissions shall be checked

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -17,17 +17,16 @@ BOT_CONTROL = "bot_control"
 COMMAND_PERMISSION = "command_permission"
 
 
-def check_command_permission(pr, event_info):
+def check_command_permission(account):
     """check if the GH account is authorized to send commands to the bot
 
     Args:
-        pr (object): pr details
-        event_info (string): event received by event_handler
+        account (string): account for which permissions shall be checked
 
     """
     fn = sys._getframe().f_code.co_name
 
-    log(f"{fn}(): checking permission for sending commands for PR {pr.number}")
+    log(f"{fn}(): checking permission for sending commands")
 
     cfg = config.read_config()
 
@@ -39,10 +38,9 @@ def check_command_permission(pr, event_info):
 
     log(f"{fn}(): command permission '{command_permission}'")
 
-    event_sender = event_info['raw_request_body']['sender']['login']
-    if event_sender not in command_permission.split():
-        log(f"{fn}(): GH account '{event_sender}' is not authorized to send commands to the bot instance")
+    if account not in command_permission.split():
+        log(f"{fn}(): GH account '{account}' is not authorized to send commands to the bot instance")
         return False
     else:
-        log(f"{fn}(): GH account '{event_sender}' is authorized to send commands")
+        log(f"{fn}(): GH account '{account}' is authorized to send commands")
         return True

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -1,0 +1,48 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+import sys
+
+from pyghee.utils import log
+from tools import config
+
+BOT_CONTROL = "bot_control"
+COMMAND_PERMISSION = "command_permission"
+
+
+def check_command_permission(pr, event_info):
+    """check if the GH account is authorized to send commands to the bot
+
+    Args:
+        pr (object): pr details
+        event_info (string): event received by event_handler
+
+    """
+    fn = sys._getframe().f_code.co_name
+
+    log(f"{fn}(): checking permission for sending commands for PR {pr.number}")
+
+    cfg = config.read_config()
+
+    bot_ctrl = cfg[BOT_CONTROL]
+
+    # verify that the GH account that has sent a command (via a adding or editing
+    # a comment) has the permission to control the bot
+    command_permission = bot_ctrl.get(COMMAND_PERMISSION, '')
+
+    log(f"{fn}(): command permission '{command_permission}'")
+
+    event_sender = event_info['raw_request_body']['sender']['login']
+    if event_sender not in command_permission.split():
+        log(f"{fn}(): GH account '{event_sender}' is not authorized to send commands to the bot instance")
+        return False
+    else:
+        log(f"{fn}(): GH account '{event_sender}' is authorized to send commands")
+        return True

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -38,9 +38,9 @@ def check_command_permission(account):
 
     log(f"{fn}(): command permission '{command_permission}'")
 
-    if account not in command_permission.split():
-        log(f"{fn}(): GH account '{account}' is not authorized to send commands to the bot instance")
-        return False
-    else:
+    if account in command_permission.split():
         log(f"{fn}(): GH account '{account}' is authorized to send commands")
         return True
+    else:
+        log(f"{fn}(): GH account '{account}' is not authorized to send commands to the bot instance")
+        return False

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -100,13 +100,16 @@ def update_comment(cmnt_id, pr, update, log_file=None):
 
 def update_pr_comment(event_info, update):
     """
-    Updates a comment to a pull request determined from an event.
+    Updates a comment to a pull request determined from an issue_comment event.
 
     Args:
         event_info (dict): storing all information of an event
         update (string): the update for the comment associated with the event
     """
     request_body = event_info['raw_request_body']
+    if 'issue' not in request_body:
+        log("event is not an issue_comment; cannot update the comment")
+        return
     comment_new = request_body['comment']['body']
     repo_name = request_body['repository']['full_name']
     pr_number = int(request_body['issue']['number'])

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -27,11 +27,14 @@ def create_comment(repo_name, pr_number, comment):
         repo_name (str): name of the repo with the pr
         pr_number (int): number of the pr within the repo
         comment (string): new comment
+
+    Returns:
+        IssueComment: data structure representing the created issue comment
     """
     gh = github.get_instance()
     repo = gh.get_repo(repo_name)
     pull_request = repo.get_pull(pr_number)
-    pull_request.create_issue_comment(comment)
+    return pull_request.create_issue_comment(comment)
 
 
 @retry(Exception, tries=5, delay=1, backoff=2, max_delay=30)
@@ -97,7 +100,7 @@ def update_comment(cmnt_id, pr, update, log_file=None):
 
 def update_pr_comment(event_info, update):
     """
-    Updates a comment determined from an event.
+    Updates a comment to a pull request determined from an event.
 
     Args:
         event_info (dict): storing all information of an event


### PR DESCRIPTION
This PR probably needs some updates/polishing but it has been tested already with a few PRs to the software-layer repository. It includes the following additions:

- class to model action filters where an action is something like submitting a build job
  - compared to setting a label `bot:build` an action can be filtered wrt a repository, an architecture and a bot instance name
  - idea is that an action is only performed if its context (repository, architecture and bot instance) matches the filter
- class to model bot commands which are composed of a command such as `help` and `build` and an action filter
- adds code to parse *NEW* comments for bot commands (beginning at the start of a line with `bot: `), displays if a command has been received, processes the command(s) and adds some result/output in the same comment
- handlers for commands: `help`, `build` and `showconfig`
- adds an `app.cfg` setting for limiting which GH accounts can send commands to the bot
- refactors existing code to work well with the addition of action filters: one major change is how configuration settings are passed to where they are accessed
- includes some polishing of docstrings and other things
- last but not least, adds some unit tests for the action filters

~TODOs~ done
- addressed the below by only running the critical code if the event is an issue_comment ... then the request_body has the key 'issue'
  - clarify that `update_pr_comment` is working only with issue comment events (not with pull request events) because it accesses the `issue` section of an event, see line (in `tools/pr_comments.py`)
    ```python
    pr_number = int(request_body['issue']['number'])
    ```
  - or change the code such that it works with both pull request events and issue comment events, e.g., by determining the type of the event