### PR TITLE
Move check result to target repo

### DIFF
--- a/app.cfg.example
+++ b/app.cfg.example
@@ -24,6 +24,13 @@ installation_id = 12345678
 private_key = PATH_TO_PRIVATE_KEY
 
 
+[bot_control]
+# which GH accounts have the permission to send commands to the bot
+# if value is left/empty everyone can send commands
+# value can be a space delimited list of GH accounts
+command_permission =
+
+
 [buildenv]
 # name of the job script used for building an EESSI stack
 build_job_script = PATH_TO_EESSI_BOT/scripts/bot-build.slurm
@@ -35,13 +42,13 @@ container_cachedir = PATH_TO_SHARED_DIRECTORY
 # it may happen that we need to customize some CVMFS configuration
 #   the value of cvmfs_customizations is a dictionary which maps a file
 #   name to an entry that needs to be added to that file
-cvmfs_customizations = { "/etc/cvmfs/default.local": "CVMFS_HTTP_PROXY=\"http://PROXY_DNS_NAME:3128|http://PROXY_IP_ADDRESS:3128\"" }
+# cvmfs_customizations = { "/etc/cvmfs/default.local": "CVMFS_HTTP_PROXY=\"http://PROXY_DNS_NAME:3128|http://PROXY_IP_ADDRESS:3128\"" }
 
 # if compute nodes have no internet connection, we need to set http(s)_proxy
 #   or commands such as pip3 cannot download software from package repositories
 #   for example, the temporary EasyBuild is installed via pip3 first
-http_proxy = http://PROXY_DNS:3128/
-https_proxy = http://PROXY_DNS:3128/
+# http_proxy = http://PROXY_DNS:3128/
+# https_proxy = http://PROXY_DNS:3128/
 
 # directory under which the bot prepares directories per job
 #   structure created is as follows: YYYY.MM/pr_PR_NUMBER/event_EVENT_ID/run_RUN_NUMBER/OS+SUBDIR
@@ -75,8 +82,11 @@ submit_command = /usr/bin/sbatch
 # the label 'bot:build' (apparently this cannot be restricted on GitHub)
 # if value is left/empty everyone can trigger the build
 # value can be a space delimited list of GH accounts
-build_permission = Hafsa-Naeem
+build_permission =
+
+# template for comment when user who set a label has no permission to trigger build jobs
 no_build_permission_comment = Label `bot:build` has been set by user `{build_labeler}`, but only users `{build_permission_users}` have permission to trigger the action
+
 
 [deploycfg]
 # script for uploading built software packages
@@ -108,7 +118,9 @@ upload_policy = once
 # the label 'bot:deploy' (apparently this cannot be restricted on GitHub)
 # if value is left/empty everyone can trigger the deployment
 # value can be a space delimited list of GH accounts
-deploy_permission = trz42
+deploy_permission =
+
+# template for comment when user who set a label has no permission to trigger deploying tarballs
 no_deploy_permission_comment = Label `bot:deploy` has been set by user `{deploy_labeler}`, but only users `{deploy_permission_users}` have permission to trigger the action
 
 
@@ -116,6 +128,16 @@ no_deploy_permission_comment = Label `bot:deploy` has been set by user `{deploy_
 # defines both for which architectures the bot will build
 #   and what submission parameters shall be used
 arch_target_map = { "linux/x86_64/generic" : "--constraint shape=c4.2xlarge", "linux/x86_64/amd/zen2": "--constraint shape=c5a.2xlarge" }
+
+
+[repo_targets]
+# defines for which repository a arch_target should be build for
+#
+# EESSI/2021.12 and NESSI/2022.11
+repo_target_map = { "linux/x86_64/amd/zen2" : ["eessi-2021.12","nessi.no-2022.11"] }
+
+# points to definition of repositories (default EESSI-pilot defined by build container)
+repos_cfg_dir = PATH_TO_SHARED_DIRECTORY/cfg_bundles
 
 
 # configuration for event handler which receives events from a GitHub repository.
@@ -141,23 +163,27 @@ poll_interval = 60
 # full path to the command for manipulating existing jobs
 scontrol_command = /usr/bin/scontrol
 
+
 # variable 'comment' under 'submitted_job_comments' should not be changed as there are regular expression patterns matching it
 [submitted_job_comments]
-initial_comment = New job on instance `{app_name}` for architecture `{arch_name}` for repository `{repo_id}` in job dir `{symlink}` 
-awaits_release = job id `{job_id}` awaits release by job manager 
+initial_comment = New job on instance `{app_name}` for architecture `{arch_name}` for repository `{repo_id}` in job dir `{symlink}`
+awaits_release = job id `{job_id}` awaits release by job manager
+
 
 [new_job_comments]
-awaits_lauch = job awaits launch by Slurm scheduler 
+awaits_lauch = job awaits launch by Slurm scheduler
+
 
 [running_job_comments]
-running_job = job `{job_id}` is running 
+running_job = job `{job_id}` is running
+
 
 [finished_job_comments]
-success = :grin: SUCCESS tarball `{tarball_name}` ({tarball_size} GiB) in job dir 
-failure = :cry: FAILURE 
-no_slurm_out = No slurm output `{slurm_out}` in job dir 
-slurm_out = Found slurm output `{slurm_out}` in job dir 
-missing_modules = Slurm output lacks message "No missing modules!". 
-no_tarball_message = Slurm output lacks message about created tarball. 
-no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir. 
-multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected. 
+success = :grin: SUCCESS tarball `{tarball_name}` ({tarball_size} GiB) in job dir
+failure = :cry: FAILURE
+no_slurm_out = No slurm output `{slurm_out}` in job dir
+slurm_out = Found slurm output `{slurm_out}` in job dir
+missing_modules = Slurm output lacks message "No missing modules!".
+no_tarball_message = Slurm output lacks message about created tarball.
+no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir.
+multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected.

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -187,3 +187,7 @@ missing_modules = Slurm output lacks message "No missing modules!".
 no_tarball_message = Slurm output lacks message about created tarball.
 no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir.
 multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected.
+job_result_comment_fmt =
+<details><summary>{summary} _click triangle for details_</summary>
+Details:<ul>{details}</ul>
+Artefacts:<ul>{artefacts}</ul>

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -187,7 +187,4 @@ missing_modules = Slurm output lacks message "No missing modules!".
 no_tarball_message = Slurm output lacks message about created tarball.
 no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir.
 multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected.
-job_result_comment_fmt =
-<details><summary>{summary} _click triangle for details_</summary>
-Details:<ul>{details}</ul>
-Artefacts:<ul>{artefacts}</ul>
+job_result_comment_fmt = <details><summary>{summary} _(click triangle for detailed information)_</summary>Details:<ul>{details}</ul>Artefacts:<ul>{artefacts}</ul>

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -135,6 +135,8 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log("update to comment is empty")
             return
 
+        comment_update += f"\n<!-- ADD NEW COMMENTS BELOW THIS LINE -->\n"
+
         if not any(map(get_bot_command, comment_update.split('\n'))):
             # the 'not any()' ensures that the update would not be considered a bot command itself
             # ... together with checking the sender of a comment update this aims

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -81,9 +81,11 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment created: '{comment_diff}'")
         elif action == 'edited':
             comment_old = request_body['changes']['body']['from']
+            self.log(f"comment edited: OLD '{comment_old}'")
             comment_new = request_body['comment']['body']
+            self.log(f"comment edited: NEW '{comment_new}'")
             comment_diff = comment_new.replace(comment_old, '')
-            self.log(f"comment edited: '{comment_diff}'")
+            self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):
             self.log(f"searching line '{line}' for bot command")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -223,7 +223,8 @@ class EESSIBotSoftwareLayer(PyGHee):
         gh = github.get_instance()
         repo = gh.get_repo(repo_name)
         pull_request = repo.get_pull(pr.number)
-        pull_request.create_issue_comment(comment)
+        comment = pull_request.create_issue_comment(comment)
+        return comment.id
 
     def handle_pull_request_event(self, event_info, log_file=None):
         """
@@ -267,7 +268,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         help_msg += "\n  - Commands must be sent with a **new** comment (edits of existing comments are ignored)."
         help_msg += "\n  - A comment may contain multiple commands, one per line."
         help_msg += "\n  - Every command begins at the start of a line and has the syntax `bot: COMMAND [ARGUMENTS]*`"
-        help_msg += "\n  - Currently supported COMMANDs are: `help`"
+        help_msg += "\n  - Currently supported COMMANDs are: `help`, `build`, `showconfig`"
         return help_msg
 
     def handle_bot_command_build(self, event_info, bot_command):
@@ -301,8 +302,14 @@ class EESSIBotSoftwareLayer(PyGHee):
 #    def handle_bot_command_status(self, event_info, bot_command):
 #        return
 
-#    def handle_bot_command_show_config(self, event_info, bot_command):
-#        return
+    def handle_bot_command_showconfig(self, event_info, bot_command):
+        self.log("processing bot command 'showconfig'")
+        gh = github.get_instance()
+        repo_name = event_info['raw_request_body']['repository']['full_name']
+        pr_number = event_info['raw_request_body']['pull_request']['number']
+        pr = gh.get_repo(repo_name).get_pull(pr_number)
+        comment_id = self.handle_pull_request_opened_event(event_info, pr)
+        return f"added comment #{comment_id} to show configuration"
 
     def start(self, app, port=3000):
         """starts the app and log information in the log file

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -89,10 +89,10 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"searching line '{line}' for bot command")
             match = re.search('^bot: (.*)$', line)
             if match:
-                self.log(f"found bot command: {match.group(1)}")
+                self.log(f"found bot command: '{match.group(1)}'")
                 comment_update += "<hr/>\n received bot command "
                 comment_update += f"{match.group(1)}\n"
-        self.log(f"comment update: {comment_update}")
+        self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']
             pr_number = int(request_body['issue']['number'])

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -127,9 +127,9 @@ class EESSIBotSoftwareLayer(PyGHee):
                 try:
                     ebc = EESSIBotCommand(bot_command)
                 except EESSIBotCommandError as bce:
-                    self.log(f"ERROR: parsing {bot_command=} failed with {bce.args}")
-                    comment_update += f"\n- parsing `{bot_command=}` received"
-                    comment_update += f" from `{sender=}` failed"
+                    self.log(f"ERROR: parsing bot command '{bot_command}' failed with {bce.args}")
+                    comment_update += f"\n- parsing bot command `{bot_command}` received"
+                    comment_update += f" from sender `{sender}` failed"
                     continue
                 commands.append(ebc)
                 self.log(f"found bot command: '{bot_command}'")
@@ -171,7 +171,7 @@ class EESSIBotSoftwareLayer(PyGHee):
                 update_pr_comment(event_info, comment_update)
                 continue
             except Exception as err:
-                log(f"Unexpected {err=}, {type(err)=}")
+                log(f"Unexpected err={err}, type(err)={type(err)}")
                 raise
 
         self.log("issue_comment event handled!")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -94,8 +94,8 @@ class EESSIBotSoftwareLayer(PyGHee):
             match = re.search('^bot: (.*)$', line)
             if match:
                 self.log(f"found bot command: '{match.group(1)}'")
-                comment_update += "\n<hr/>\n- received bot command "
-                comment_update += f"`{match.group(1)}`\n"
+                comment_update += "\n- received bot command "
+                comment_update += f"`{match.group(1)}`"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -275,7 +275,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         gh = github.get_instance()
         self.log("repository: '%s'", event_info['raw_request_body']['repository']['full_name'])
         repo_name = event_info['raw_request_body']['repository']['full_name']
-        pr_number = event_info['raw_request_body']['pull_request']['number']
+        pr_number = event_info['raw_request_body']['issue']['number']
         pr = gh.get_repo(repo_name).get_pull(pr_number)
         build_msg = ''
         if check_build_permission(pr, event_info):
@@ -306,7 +306,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         self.log("processing bot command 'showconfig'")
         gh = github.get_instance()
         repo_name = event_info['raw_request_body']['repository']['full_name']
-        pr_number = event_info['raw_request_body']['pull_request']['number']
+        pr_number = event_info['raw_request_body']['issue']['number']
         pr = gh.get_repo(repo_name).get_pull(pr_number)
         comment_id = self.handle_pull_request_opened_event(event_info, pr)
         return f"added comment #{comment_id} to show configuration"

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -86,7 +86,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: NEW '{comment_new}'")
             if len(comment_old) < len(comment_new):
                 comment_diff = comment_new[len(comment_old):]
-                self.log(f"comment edited: NEW shorter than OLD (assume cleanup -> no action)")
+                self.log("comment edited: NEW shorter than OLD (assume cleanup -> no action)")
             self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):
@@ -95,7 +95,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             if match:
                 self.log(f"found bot command: '{match.group(1)}'")
                 comment_update += "\n- received bot command "
-                comment_update += f"`{match.group(1)}`"
+                comment_update += f"`{match.group(1).rstrip()}`"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -105,6 +105,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: NEW '{comment_new}'")
             if len(comment_old) < len(comment_new):
                 comment_diff = comment_new[len(comment_old):]
+            else:
                 self.log("comment edited: NEW shorter than OLD (assume cleanup -> no action)")
             self.log(f"comment edited: DIFF '{comment_diff}'")
 
@@ -123,9 +124,9 @@ class EESSIBotSoftwareLayer(PyGHee):
             else:
                 self.log(f"`{line}` is not considered to contain a bot command")
                 # TODO keep the below for debugging purposes
-                comment_update += "\n- line `{line}` is not considered to contain a bot command"
-                comment_update += "\n  bot commands begin with `bot: `, make sure"
-                comment_update += "\n  there is no whitespace at the beginning of a line"
+                #comment_update += "\n- line <code>{line}</code> is not considered to contain a bot command"
+                #comment_update += "\n  bot commands begin with `bot: `, make sure"
+                #comment_update += "\n  there is no whitespace at the beginning of a line"
         self.log(f"comment update: '{comment_update}'")
         if comment_update == '':
             # no update to be added, just log and return

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -84,7 +84,9 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: OLD '{comment_old}'")
             comment_new = request_body['comment']['body']
             self.log(f"comment edited: NEW '{comment_new}'")
-            comment_diff = comment_new[len(comment_old):]
+            if len(comment_old) < len(comment_new):
+                comment_diff = comment_new[len(comment_old):]
+                self.log(f"comment edited: NEW shorter than OLD (assume cleanup -> no action)")
             self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):
@@ -92,8 +94,8 @@ class EESSIBotSoftwareLayer(PyGHee):
             match = re.search('^bot: (.*)$', line)
             if match:
                 self.log(f"found bot command: '{match.group(1)}'")
-                comment_update += "<hr/>\n received bot command "
-                comment_update += f"{match.group(1)}\n"
+                comment_update += "\n<hr/>\n- received bot command "
+                comment_update += f"`{match.group(1)}`\n"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -64,7 +64,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         sender = request_body['sender']['login']
         owner = request_body['comment']['user']['login']
         txt = request_body['comment']['body']
-        self.log(f"Comment in {issue_url} {action} by @{sender} (owned by @{owner}): {txt}")
+        self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}: {txt}")
         # check if addition to comment includes a command for the bot, e.g.,
         #   bot: rebuild [arch:intel] [instance:AWS]
         #   bot: cancel [job:jobid]
@@ -96,7 +96,9 @@ class EESSIBotSoftwareLayer(PyGHee):
         # determine what is new in comment
         comment_diff = ''
         if action == 'created':
-            comment_diff = request_body['comment']['body']
+            comment_old = ''
+            comment_new = request_body['comment']['body']
+            comment_diff = comment_new[len(comment_old):]
             self.log(f"comment created: '{comment_diff}'")
         elif action == 'edited':
             comment_old = request_body['changes']['body']['from']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -96,6 +96,9 @@ class EESSIBotSoftwareLayer(PyGHee):
                 self.log(f"found bot command: '{match.group(1)}'")
                 comment_update += "\n- received bot command "
                 comment_update += f"`{match.group(1).rstrip()}`"
+                comment_update += f" from `{comment_author}`"
+            else:
+                self.log(f"`{line}` is not considered to contain a bot command")
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -84,7 +84,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             self.log(f"comment edited: OLD '{comment_old}'")
             comment_new = request_body['comment']['body']
             self.log(f"comment edited: NEW '{comment_new}'")
-            comment_diff = comment_new.replace(comment_old, '')
+            comment_diff = comment_new[len(comment_old):]
             self.log(f"comment edited: DIFF '{comment_diff}'")
         comment_update = ''
         for line in comment_diff.split('\n'):

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -74,19 +74,25 @@ class EESSIBotSoftwareLayer(PyGHee):
         #  - scan what's new for commands 'bot: COMMAND [ARGS*]'
         #  - process commands
         action = request_body['action']
+        self.log(f"comment action: {action}")
         comment_diff = ''
         if action == 'created':
             comment_diff = request_body['comment']['body']
+            self.log(f"comment created: '{comment_diff}'")
         elif action == 'edited':
             comment_old = request_body['changes']['body']['from']
             comment_new = request_body['comment']['body']
             comment_diff = comment_new.replace(comment_old, '')
+            self.log(f"comment edited: '{comment_diff}'")
         comment_update = ''
-        for new_line in comment_diff.split('\n'):
-            match = re.search('^bot: (.*)$', new_line)
+        for line in comment_diff.split('\n'):
+            self.log(f"searching line '{line}' for bot command")
+            match = re.search('^bot: (.*)$', line)
             if match:
+                self.log(f"found bot command: {match.group(1)}")
                 comment_update += "<hr/>\n received bot command "
                 comment_update += f"{match.group(1)}\n"
+        self.log(f"comment update: {comment_update}")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']
             pr_number = int(request_body['issue']['number'])

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -64,7 +64,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         sender = request_body['sender']['login']
         owner = request_body['comment']['user']['login']
         txt = request_body['comment']['body']
-        self.log("Comment in {issue_url} {action} by @{sender} (owned by @{owner}): {txt}")
+        self.log(f"Comment in {issue_url} {action} by @{sender} (owned by @{owner}): {txt}")
         # check if addition to comment includes a command for the bot, e.g.,
         #   bot: rebuild [arch:intel] [instance:AWS]
         #   bot: cancel [job:jobid]
@@ -124,9 +124,9 @@ class EESSIBotSoftwareLayer(PyGHee):
             else:
                 self.log(f"'{line}' is not considered to contain a bot command")
                 # TODO keep the below for debugging purposes
-                #comment_update += "\n- line <code>{line}</code> is not considered to contain a bot command"
-                #comment_update += "\n  bot commands begin with `bot: `, make sure"
-                #comment_update += "\n  there is no whitespace at the beginning of a line"
+                # comment_update += "\n- line <code>{line}</code> is not considered to contain a bot command"
+                # comment_update += "\n  bot commands begin with `bot: `, make sure"
+                # comment_update += "\n  there is no whitespace at the beginning of a line"
         self.log(f"comment update: '{comment_update}'")
         if comment_update == '':
             # no update to be added, just log and return

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -99,6 +99,9 @@ class EESSIBotSoftwareLayer(PyGHee):
                 comment_update += f" from `{comment_author}`"
             else:
                 self.log(f"`{line}` is not considered to contain a bot command")
+                comment_update += "\n- line `{line}` is not considered to contain a bot command"
+                comment_update += "\n  bot commands begin with `bot: `, make sure"
+                comment_update += "\n  there is no whitespace at the beginning of a line"
         self.log(f"comment update: '{comment_update}'")
         if len(comment_update):
             repo_name = request_body['repository']['full_name']

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -441,13 +441,18 @@ class EESSIBotSoftwareLayerJobManager:
                 details=details,
                 built_artefacts=built_artefacts
             )
-        # we should only gotten here if there was no job result file or it could
-        # not be read. if the old code has been moved to the target repository we
-        # need to add a standard message ala "UNKNOWN result because no job
-        # result file found"
+
+            # establish contact to pull request on github
+            gh = github.get_instance()
+
+        # we should only gotten here if there was no job result file or it
+        # could not be read. if the old code has been moved to the target
+        # repository we need to add a standard message ala "UNKNOWN result
+        # because no job result file found"
 
         # NOTE if also the deploy functionality is changed such to use the
-        #      results file the bot really becomes independent of what it builds
+        #      results file the bot really becomes independent of what it
+        #      builds
 
         # TODO the below should be done by the target repository's script
         #      bot/check-result.sh which should produce a file
@@ -471,15 +476,15 @@ class EESSIBotSoftwareLayerJobManager:
         job_dir = os.path.join(self.submitted_jobs_dir, finished_job["jobid"])
         sym_dst = os.readlink(job_dir)
 
-        # TODO create function for obtaining values from metadata file
-        #        might be based on allowing multiple configuration files
-        #        in tools/config.py
+        # read some information from job metadata file
         metadata_file = "_bot_job%s.metadata" % finished_job["jobid"]
         job_metadata_path = os.path.join(job_dir, metadata_file)
 
         # check if metadata file exist
         metadata_pr = self.read_job_pr_metadata(job_metadata_path)
         if metadata_pr is None:
+            # TODO should we raise the Exception here? maybe first process
+            #      the finished job and raise an exception at the end?
             raise Exception("Unable to find metadata file")
 
         # get repo name

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -425,7 +425,22 @@ class EESSIBotSoftwareLayerJobManager:
         job_results = self.read_job_result(job_result_file_path)
         if job_results:
             # TODO process results & return
+            # get summary
+            summary = job_results.get(JOB_RESULT_SUMMARY, ":shrug: UNKOWN")
+            # get details
+            details = job_results.get(JOB_RESULT_DETAILS, "* _no details provided_")
+            # get built_artefacts
+            built_artefacts = job_results.get(JOB_RESULT_ARTEFACTS, "* _no built artefacts reported_")
 
+            dt = datetime.now(timezone.utc)
+
+            job_result_comment_fmt = config.read_config()[JOB_RESULT_COMMENT_FMT]
+            comment_update = f"\n|{dt.strftime('%b %d %X %Z %Y')}|finished|"
+            comment_update += job_result_comment_fmt.format(
+                summary=summary,
+                details=details,
+                built_artefacts=built_artefacts
+            )
         # we should only gotten here if there was no job result file or it could
         # not be read. if the old code has been moved to the target repository we
         # need to add a standard message ala "UNKNOWN result because no job

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -28,7 +28,7 @@
 # license: GPLv2
 #
 
-import configparser
+# import configparser
 import glob
 import os
 import re
@@ -43,7 +43,7 @@ from tools import config, run_cmd
 from tools.pr_comments import get_submitted_job_comment, update_comment, make_html_list_items
 from tools.job_metadata import read_metadata_file
 
-from pyghee.utils import log, error
+from pyghee.utils import log
 
 AWAITS_LAUCH = "awaits_lauch"
 FAILURE = "failure"
@@ -445,9 +445,6 @@ class EESSIBotSoftwareLayerJobManager:
         #     resources_requested=CPU:x,RAM:yG,DISK:zG
         #     resources_allocated=CPU:x,RAM:yG,DISK:zG
         #     resources_used=CPU:x,RAM:yG,DISK:zG
-        # OLD
-        #   if file doesn't exist, use the below procedure (only until target
-        #   repositories are updated to create such a result file)
 
         # NEW check if _bot_jobJOBID.result exits
         job_result_file = f"_bot_job{job_id}.result"
@@ -507,12 +504,10 @@ class EESSIBotSoftwareLayerJobManager:
 
             update_comment(pr_comment_id, pull_request, comment_update)
 
-            return
+        return
 
-        # we should only gotten here if there was no job result file or it
-        # could not be read. if the old code has been moved to the target
-        # repository we need to add a standard message ala "UNKNOWN result
-        # because no job result file found"
+        # we should not gotten here because scripts/bot-build.slurm creates
+        # a default results file if bot/check-result.sh doesn't exist
 
         # NOTE if also the deploy functionality is changed such to use the
         #      results file the bot really becomes independent of what it

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -68,7 +68,8 @@ REQUIRED_CONFIG = {
     NEW_JOB_COMMENTS: [AWAITS_LAUCH],
     RUNNING_JOB_COMMENTS: [RUNNING_JOB],
     FINISHED_JOB_COMMENTS: [SUCCESS, FAILURE, NO_SLURM_OUT, SLURM_OUT, MISSING_MODULES,
-                            NO_TARBALL_MESSAGE, NO_MATCHING_TARBALL, MULTIPLE_TARBALLS]
+                            NO_TARBALL_MESSAGE, NO_MATCHING_TARBALL, MULTIPLE_TARBALLS,
+                            JOB_RESULT_COMMENT_FMT]
 }
 
 
@@ -455,10 +456,10 @@ class EESSIBotSoftwareLayerJobManager:
             # get summary
             summary = job_results.get(JOB_RESULT_SUMMARY, ":shrug: UNKOWN")
             # get details
-            details = job_results.get(JOB_RESULT_DETAILS, "_no details provided_")
+            details = job_results.get(JOB_RESULT_DETAILS, "No details were provided.")
             details_list = make_html_list_items(details)
             # get built_artefacts
-            artefacts = job_results.get(JOB_RESULT_ARTEFACTS, "_no artefacts reported_")
+            artefacts = job_results.get(JOB_RESULT_ARTEFACTS, "No artefacts were found/reported.")
             artefacts_list = make_html_list_items(artefacts)
 
             # TODO report to log
@@ -471,7 +472,8 @@ class EESSIBotSoftwareLayerJobManager:
 
             dt = datetime.now(timezone.utc)
 
-            job_result_comment_fmt = config.read_config()[JOB_RESULT_COMMENT_FMT]
+            finished_job_comments_cfg = config.read_config()[FINISHED_JOB_COMMENTS]
+            job_result_comment_fmt = finished_job_comments_cfg[JOB_RESULT_COMMENT_FMT]
             comment_update = f"\n|{dt.strftime('%b %d %X %Z %Y')}|finished|"
             comment_update += job_result_comment_fmt.format(
                 summary=summary,
@@ -502,7 +504,7 @@ class EESSIBotSoftwareLayerJobManager:
             repo = gh.get_repo(repo_name)
             pull_request = repo.get_pull(int(pr_number))
 
-            update_comment(pr_comment_id, pull_request, comment_update)
+            update_comment(int(pr_comment_id), pull_request, comment_update)
 
         return
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -196,7 +196,11 @@ class EESSIBotSoftwareLayerJobManager:
         Check if metadata file exists, read it and return 'PR' section if so, return None if not.
         """
         # just use a function provided by module tools.job_metadata
-        return read_metadata_file(job_metadata_path, self.logfile)
+        metadata = read_metadata_file(job_metadata_path, self.logfile)
+        if metadata and "PR" in metadata:
+            return metadata["PR"]
+        else:
+            return None
 
     # job_manager.process_new_job(current_jobs[nj])
     def process_new_job(self, new_job):

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -202,6 +202,17 @@ class EESSIBotSoftwareLayerJobManager:
         else:
             return None
 
+    def read_job_result(self, job_result_file_path):
+        """
+        Check if result file exists, read it and return 'RESULT section if so, return None if not.
+        """
+        # just use a function provided by module tools.job_metadata
+        result = read_metadata_file(job_result_file_path, self.logfile)
+        if result and "RESULT" in result:
+            return result["RESULT"]
+        else:
+            return None
+
     # job_manager.process_new_job(current_jobs[nj])
     def process_new_job(self, new_job):
         # create symlink in submitted_jobs_dir (destination is the working
@@ -395,8 +406,9 @@ class EESSIBotSoftwareLayerJobManager:
         # 1. check if file _bot_jobJOBID.result exists --> if so read it and
         #    prepare update to PR comment
         #    result file contents:
-        #      result={SUCCESS|FAILURE|UNKNOWN}
-        #      msg=multiline string that is put into details element
+        #      [RESULT]
+        #      summary={SUCCESS|FAILURE|UNKNOWN}
+        #      details=multiline string that is put into details element
         #      built_artefacts=multiline string with (relative) path names
         #      jobid=
         #      runtime=

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -23,23 +23,27 @@
 #    for example, repos.cfg and configuration file bundles for repositories
 
 echo "Starting bot-build.slurm"
-if [ -f bot/build.sh ]; then
-    echo "bot/build.sh script found in '${PWD}', so running it!"
-    bot/build.sh
+BOT_BUILD_SCRIPT=bot/build.sh
+if [ -f ${BOT_BUILD_SCRIPT} ]; then
+    echo "${BOT_BUILD_SCRIPT} script found in '${PWD}', so running it!"
+    ${BOT_BUILD_SCRIPT}
 else
-    fatal_error "could not find bot/build.sh script in '${PWD}'"
+    fatal_error "could not find ${BOT_BUILD_SCRIPT} script in '${PWD}'"
 fi
 echo "bot/build.sh finished"
-if [ -f bot/check-result.sh ]; then
-    echo "bot/check-result.sh script found in '${PWD}', so running it!"
-    bot/check-result.sh
+CHECK_RESULT_SCRIPT=_bot/check-result.sh
+if [ -f ${CHECK_RESULT_SCRIPT} ]; then
+    echo "${CHECK_RESULT_SCRIPT} script found in '${PWD}', so running it!"
+    ${CHECK_RESULT_SCRIPT}
 else
-    echo "could not find bot/check-result.sh script in '${PWD}' ..."
+    echo "could not find ${CHECK_RESULT_SCRIPT} script in '${PWD}' ..."
     echo "... depositing default _bot_job${SLURM_JOB_ID}.result file in '${PWD}'"
-    cat > _bot_job${SLURM_JOB_ID}.result <<EOF
+    cat << 'EOF' > _bot_job${SLURM_JOB_ID}.result
 [RESULT]
-summary=UNKNOWN
-details="Did not find bot/check-result.sh script in '${PWD}'. Check job manually."
+summary = :shrug: UNKNOWN
+details =
+    Did not find `bot/check-result.sh` script in job's work directory.
+    *Check job manually or ask an admin of the bot instance to assist you.*
 EOF
 fi
 echo "check result step finished"

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -37,8 +37,9 @@ else
     echo "could not find bot/check-result.sh script in '${PWD}' ..."
     echo "... depositing default _bot_job${SLURM_JOB_ID}.result file in '${PWD}'"
     cat > _bot_job${SLURM_JOB_ID}.result <<EOF
-result=UNKNOWN
-msg="Did not find bot/check-result.sh script in '${PWD}'. Check job manually."
+[RESULT]
+summary=UNKNOWN
+details="Did not find bot/check-result.sh script in '${PWD}'. Check job manually."
 EOF
 fi
 echo "check result step finished"

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -29,3 +29,16 @@ if [ -f bot/build.sh ]; then
 else
     fatal_error "could not find bot/build.sh script in '${PWD}'"
 fi
+echo "bot/build.sh finished"
+if [ -f bot/check-result.sh ]; then
+    echo "bot/check-result.sh script found in '${PWD}', so running it!"
+    bot/check-result.sh
+else
+    echo "could not find bot/check-result.sh script in '${PWD}' ..."
+    echo "... depositing default _bot_job${SLURM_JOB_ID}.result file in '${PWD}'"
+    cat > _bot_job${SLURM_JOB_ID}.result <<EOF
+result=UNKNOWN
+msg="Did not find bot/check-result.sh script in '${PWD}'. Check job manually."
+EOF
+fi
+echo "check result step finished"

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -24,6 +24,7 @@ from pyghee.utils import log, error
 from retry.api import retry_call
 from tools import config, run_cmd
 from tools.job_metadata import create_metadata_file
+from tools.pr_comments import PRComment
 
 APP_NAME = "app_name"
 AWAITS_RELEASE = "awaits_release"

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -655,8 +655,10 @@ def submit_build_jobs(pr, event_info, action_filter):
         # report submitted job
         pr_comment_id = create_pr_comment(job, job_id, app_name, pr, gh, symlink)
 
+        pr_comment = PRComment(pr.base.repo.full_name, pr.number, pr_comment_id)
+
         # create _bot_job<jobid>.metadata file in submission directory
-        create_metadata_file(job, job_id, pr, pr_comment_id)
+        create_metadata_file(job, job_id, pr_comment)
 
     return_msg = f"created jobs: {', '.join(job_ids)}"
     return return_msg

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -354,6 +354,10 @@ def prepare_jobs(pr, event_dir, build_env_cfg, arch_map, repocfg):
             if repo_id != "EESSI-pilot" and repo_id not in repocfg:
                 log(f"{fn}(): skipping repo {repo_id}, it is not defined in repo config {repocfg[REPOS_CFG_DIR]}")
                 continue
+
+            # TODO check filter: context = (arch, repo, app_name)
+            #      passed --> log & go on
+            #      missed --> log & continue
             job_dir = os.path.join(event_dir, arch_dir, repo_id)
             os.makedirs(job_dir, exist_ok=True)
             log(f"{fn}(): job_dir '{job_dir}'")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from pyghee.utils import log, error
 from retry.api import retry_call
 from tools import config, run_cmd
+from tools.job_metadata import create_metadata_file
 
 APP_NAME = "app_name"
 AWAITS_RELEASE = "awaits_release"
@@ -570,28 +571,6 @@ def submit_job(job, cfg):
     os.symlink(job[0], symlink)
 
     return job_id, symlink
-
-
-def create_metadata_file(job, job_id, pr, pr_comment_id):
-    """Create metadata file in submission dir.
-
-    Args:
-        job (named tuple): key data about job that has been submitted
-        job_id (string): id of submitted job
-        pr (github.PullRequest.Pullrequest): object to interact with pull request
-        pr_comment_id (int): id of PR comment
-    """
-    fn = sys._getframe().f_code.co_name
-
-    repo_name = pr.base.repo.full_name
-
-    # create _bot_job<jobid>.metadata file in submission directory
-    bot_jobfile = configparser.ConfigParser()
-    bot_jobfile['PR'] = {'repo': repo_name, 'pr_number': pr.number, 'pr_comment_id': pr_comment_id}
-    bot_jobfile_path = os.path.join(job.working_dir, f'_bot_job{job_id}.metadata')
-    with open(bot_jobfile_path, 'w') as bjf:
-        bot_jobfile.write(bjf)
-    log(f"{fn}(): created job metadata file {bot_jobfile_path}")
 
 
 def create_pr_comment(job, job_id, app_name, pr, gh, symlink):

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -397,7 +397,7 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
             #   false --> log & continue
             if action_filter:
                 log(f"{fn}(): checking filter {action_filter.to_string()}")
-                context = {{"architecture": arch}, {"repository": repo_id}, {"instance": app_name}}
+                context = {"architecture": arch, "repository": repo_id, "instance": app_name}
                 log(f"{fn}(): context is '{json.dumps(context, indent=4)}'")
                 if not action_filter.check_filters(context):
                     log(f"{fn}(): context does NOT satisfy filter(s), skipping")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -319,13 +319,13 @@ def apply_cvmfs_customizations(cvmfs_customizations, arch_job_dir):
             #      for now, only existing mappings may be customized
 
 
-def prepare_jobs(pr, event_dir, build_env_cfg, arch_map, repocfg):
+def prepare_jobs(pr, run_dir, build_env_cfg, arch_map, repocfg):
     """prepare job directory with pull request and cfg/job.cfg as well as
        additional config files
 
     Args:
         pr: github.PullRequest.Pullrequest object
-        event_dir: base directory for all jobs created for this event
+        run_dir: base directory for all jobs created for this event
         build_env_cfg: build env configuration
         arch_map: maps OS/SW_DIR to Slurm parameters
         repocfg: repository config
@@ -358,7 +358,10 @@ def prepare_jobs(pr, event_dir, build_env_cfg, arch_map, repocfg):
             # TODO check filter: context = (arch, repo, app_name)
             #      passed --> log & go on
             #      missed --> log & continue
-            job_dir = os.path.join(event_dir, arch_dir, repo_id)
+            # what is the state of the job, directory tree at this point? can we defer some to after we have checked the filter?
+            # - list functions called from eessi_bot_event_handler.py to here and what they do (changes on disk, data structures, calls to GH, ...)
+            # - determine if and how those need and can be deferred
+            job_dir = os.path.join(run_dir, arch_dir, repo_id)
             os.makedirs(job_dir, exist_ok=True)
             log(f"{fn}(): job_dir '{job_dir}'")
 

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -45,7 +45,8 @@ def determine_job_dirs(pr_number):
     #  - we may have to scan multiple YYYY.MM directories if the PR was
     #    processed over more than one month
     #  - we assume that job IDs are positive integer numbers
-    build_env_cfg = get_build_env_cfg()
+    cfg = config.read_config()
+    build_env_cfg = get_build_env_cfg(cfg)
     jobs_base_dir = build_env_cfg[JOBS_BASE_DIR]
     log(f"{funcname}(): jobs_base_dir = {jobs_base_dir}")
 

--- a/tests/test_app.cfg
+++ b/tests/test_app.cfg
@@ -4,21 +4,21 @@
 
 # variable 'comment' under 'submitted_job_comments' should not be changed as there are regular expression patterns matching it
 [submitted_job_comments]
-initial_comment = New job on instance `{app_name}` for architecture `{arch_name}` for repository `{repo_id}` in job dir `{symlink}` 
-awaits_release = job id `{job_id}` awaits release by job manager 
+initial_comment = New job on instance `{app_name}` for architecture `{arch_name}` for repository `{repo_id}` in job dir `{symlink}`
+awaits_release = job id `{job_id}` awaits release by job manager
 
 [new_job_comments]
-awaits_lauch = job awaits launch by Slurm scheduler 
+awaits_lauch = job awaits launch by Slurm scheduler
 
 [running_job_comments]
-running_job = job `{job_id}` is running 
+running_job = job `{job_id}` is running
 
 [finished_job_comments]
-success = :grin: SUCCESS tarball `{tarball_name}` ({tarball_size} GiB) in job dir 
-failure = :cry: FAILURE 
-no_slurm_out = No slurm output `{slurm_out}` in job dir 
-slurm_out = Found slurm output `{slurm_out}` in job dir 
-missing_modules = Slurm output lacks message "No missing modules!". 
-no_tarball_message = Slurm output lacks message about created tarball. 
-no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir. 
-multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected. 
+success = :grin: SUCCESS tarball `{tarball_name}` ({tarball_size} GiB) in job dir
+failure = :cry: FAILURE
+no_slurm_out = No slurm output `{slurm_out}` in job dir
+slurm_out = Found slurm output `{slurm_out}` in job dir
+missing_modules = Slurm output lacks message "No missing modules!".
+no_tarball_message = Slurm output lacks message about created tarball.
+no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir.
+multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected.

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -178,7 +178,7 @@ class MockRepository:
 
 class MockPullRequest:
     def __init__(self, pr_number, create_raises='0', create_exception=Exception, create_fails=False):
-        self.pr_number = pr_number
+        self.number = pr_number
         self.issue_comments = []
         self.create_fails = create_fails
         self.create_raises = create_raises

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -154,8 +154,12 @@ class MockGitHub:
         repo = self.repos[repo_name]
         return repo
 
+
 MockBase = namedtuple('MockBase', ['repo'])
+
+
 MockRepo = namedtuple('MockRepo', ['full_name'])
+
 
 class MockRepository:
     def __init__(self, repo_name):

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -20,6 +20,7 @@ import shutil
 from unittest.mock import patch
 
 # Third party imports (anything installed into the local Python environment)
+from collections import namedtuple
 from datetime import datetime
 import pytest
 
@@ -153,6 +154,8 @@ class MockGitHub:
         repo = self.repos[repo_name]
         return repo
 
+MockBase = namedtuple('MockBase', ['repo'])
+MockRepo = namedtuple('MockRepo', ['full_name'])
 
 class MockRepository:
     def __init__(self, repo_name):
@@ -165,6 +168,7 @@ class MockRepository:
         else:
             self.pull_requests[pr_number] = MockPullRequest(pr_number, create_raises,
                                                             CreateIssueCommentException, create_fails)
+            self.pull_requests[pr_number].base = MockBase(MockRepo(self.repo_name))
             return self.pull_requests[pr_number]
 
     def get_pull(self, pr_number):

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -180,6 +180,7 @@ class MockPullRequest:
         self.create_raises = create_raises
         self.create_exception = create_exception
         self.create_call_count = 0
+        self.base = None
 
     def create_issue_comment(self, body):
         def should_raise_exception():

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -20,6 +20,7 @@ import shutil
 from unittest.mock import patch
 
 # Third party imports (anything installed into the local Python environment)
+from datetime import datetime
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
@@ -267,18 +268,21 @@ def test_create_pr_comment_succeeds(mocked_github, tmpdir):
     shutil.copyfile("tests/test_app.cfg", "app.cfg")
     # creating a PR comment
     print("CREATING PR COMMENT")
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up")
+    ym = datetime.today().strftime('%Y.%m')
+    pr_number = 1
+    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up", ym, pr_number)
+
     job_id = "123"
     app_name = "pytest"
-    pr_number = 1
+
     repo_name = "EESSI/software-layer"
+    repo = mocked_github.get_repo(repo_name)
+    pr = repo.get_pull(pr_number)
     symlink = "/symlink"
-    comment_id = create_pr_comment(job, job_id, app_name, pr_number, repo_name, mocked_github, symlink)
+    comment_id = create_pr_comment(job, job_id, app_name, pr, mocked_github, symlink)
     assert comment_id == 1
     # check if created comment includes jobid?
     print("VERIFYING PR COMMENT")
-    repo = mocked_github.get_repo(repo_name)
-    pr = repo.get_pull(pr_number)
     comment = get_submitted_job_comment(pr, job_id)
     assert job_id in comment.body
 

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -25,9 +25,10 @@ from datetime import datetime
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from tasks.build import Job, create_metadata_file, create_pr_comment
+from tasks.build import Job, create_pr_comment
 from tools import run_cmd, run_subprocess
-from tools.pr_comments import get_submitted_job_comment
+from tools.pr_comments import get_submitted_job_comment, PRComment
+from tools.job_metadata import create_metadata_file
 
 # Local tests imports (reusing code from other tests)
 from tests.test_tools_pr_comments import MockIssueComment
@@ -412,9 +413,9 @@ def test_create_metadata_file(mocked_github, tmpdir):
 
     repo_name = "test_repo"
     pr_comment_id = 77
-    repo = mocked_github.get_repo(repo_name)
-    pr = repo.get_pull(pr_number)
-    create_metadata_file(job, job_id, pr, pr_comment_id)
+    pr_comment = PRComment(repo_name, pr_number, pr_comment_id)
+
+    create_metadata_file(job, job_id, pr_comment)
 
     expected_file = f"_bot_job{job_id}.metadata"
     expected_file_path = os.path.join(tmpdir, expected_file)
@@ -434,14 +435,14 @@ def test_create_metadata_file(mocked_github, tmpdir):
     job2 = Job(dir_does_not_exist, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id2 = "222"
     with pytest.raises(FileNotFoundError):
-        create_metadata_file(job2, job_id2, pr, pr_comment_id)
+        create_metadata_file(job2, job_id2, pr_comment)
 
     # use directory without write permission
     dir_without_write_perm = os.path.join("/")
     job3 = Job(dir_without_write_perm, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id3 = "333"
     with pytest.raises(OSError):
-        create_metadata_file(job3, job_id3, pr, pr_comment_id)
+        create_metadata_file(job3, job_id3, pr_comment)
 
     # disk quota exceeded (difficult to create and unlikely to happen because
     # partition where file is stored is usually very large)
@@ -450,7 +451,7 @@ def test_create_metadata_file(mocked_github, tmpdir):
     # job_id = None
     job4 = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id4 = None
-    create_metadata_file(job4, job_id4, pr, pr_comment_id)
+    create_metadata_file(job4, job_id4, pr_comment)
 
     expected_file4 = f"_bot_job{job_id}.metadata"
     expected_file_path4 = os.path.join(tmpdir, expected_file4)
@@ -466,4 +467,4 @@ def test_create_metadata_file(mocked_github, tmpdir):
     job5 = Job(None, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id5 = "555"
     with pytest.raises(TypeError):
-        create_metadata_file(job5, job_id5, pr, pr_comment_id)
+        create_metadata_file(job5, job_id5, pr_comment)

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -30,7 +30,7 @@ def test_add_single_action_filter():
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
-    expected = "architecture:.*intel.*\n"
+    expected = "architecture:.*intel.*"
     actual = af.to_string()
     assert expected == actual
 
@@ -62,7 +62,7 @@ def test_check_matching_simple_filter():
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
-    expected = f"architecture:{pattern}\n"
+    expected = f"architecture:{pattern}"
     actual = af.to_string()
     assert expected == actual
 
@@ -88,9 +88,9 @@ def complex_filter():
 
 
 def test_create_complex_filter(complex_filter):
-    expected = "architecture:.*intel.*\n"
-    expected += "repository:nessi.no-2022.*\n"
-    expected += "instance:[aA]\n"
+    expected = "architecture:.*intel.*"
+    expected += " repository:nessi.no-2022.*"
+    expected += " instance:[aA]"
     actual = complex_filter.to_string()
     assert expected == actual
 

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -19,14 +19,14 @@ from tools.filter import EESSIBotActionFilter
 
 
 def test_empty_action_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     expected = ''
     actual = af.to_string()
     assert expected == actual
 
 
 def test_add_single_action_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
@@ -36,7 +36,7 @@ def test_add_single_action_filter():
 
 
 def test_add_non_supported_component():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component = 'machine'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
@@ -46,7 +46,7 @@ def test_add_non_supported_component():
 
 
 def test_check_matching_empty_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     expected = ''
     actual = af.to_string()
     assert expected == actual
@@ -58,7 +58,7 @@ def test_check_matching_empty_filter():
 
 
 def test_check_matching_simple_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component = 'arch'
     pattern = '.*intel.*'
     af.add_filter(component, pattern)
@@ -74,7 +74,7 @@ def test_check_matching_simple_filter():
 
 @pytest.fixture
 def complex_filter():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component1 = 'arch'
     pattern1 = '.*intel.*'
     af.add_filter(component1, pattern1)
@@ -125,7 +125,7 @@ def test_non_match_architecture_repository_context(complex_filter):
 
 @pytest.fixture
 def arch_filter_slash_syntax():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component1 = 'arch'
     pattern1 = '.*/intel/.*'
     af.add_filter(component1, pattern1)
@@ -146,7 +146,7 @@ def test_match_architecture_syntax_slash(arch_filter_slash_syntax):
 
 @pytest.fixture
 def arch_filter_dash_syntax():
-    af = EESSIBotActionFilter()
+    af = EESSIBotActionFilter("")
     component1 = 'arch'
     pattern1 = '.*-intel-.*'
     af.add_filter(component1, pattern1)

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -15,7 +15,7 @@
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from tools.filter import EESSIBotActionFilter
+from tools.filter import EESSIBotActionFilter, EESSIBotActionFilterError
 
 
 def test_empty_action_filter():
@@ -39,10 +39,9 @@ def test_add_non_supported_component():
     af = EESSIBotActionFilter("")
     component = 'machine'
     pattern = '.*intel.*'
-    af.add_filter(component, pattern)
-    expected = ''
-    actual = af.to_string()
-    assert expected == actual
+    with pytest.raises(Exception) as err:
+        af.add_filter(component, pattern)
+    assert err.type == EESSIBotActionFilterError
 
 
 def test_check_matching_empty_filter():

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -58,4 +58,5 @@ class EESSIBotCommand:
             self.action_filters = EESSIBotActionFilter("")
 
     def to_string(self):
-        return f"{self.command} {self.action_filters.to_string()}"
+        action_filters_str = self.action_filters.to_string()
+        return f"{' '.join([self.command, action_filters_str]}"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -59,4 +59,4 @@ class EESSIBotCommand:
 
     def to_string(self):
         action_filters_str = self.action_filters.to_string()
-        return f"{' '.join([self.command, action_filters_str]}"
+        return f"{' '.join([self.command, action_filters_str])}"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -12,7 +12,7 @@ import re
 import sys
 
 from pyghee.utils import log
-from tools.filter import Filter, EESSIBotActionFilter, EESSIBotActionFilterError
+from tools.filter import EESSIBotActionFilter, EESSIBotActionFilterError
 
 
 def get_bot_command(line):
@@ -49,13 +49,13 @@ class EESSIBotCommand:
             except EESSIBotActionFilterError as baf:
                 reason = baf.args
                 log(f"ERROR: EESSIBotActionFilterError - {reason}")
-                self.action_filters = []
+                self.action_filters = None
                 raise EESSIBotCommandError("invalid action filter")
             except Exception as err:
                 log(f"Unexpected {err=}, {type(err)=}")
                 raise
         else:
-            self.action_filters = []
+            self.action_filters = EESSIBotActionFilter("")
 
     def to_string(self):
         return f"{self.command} {self.action_filters.to_string()}"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -52,7 +52,7 @@ class EESSIBotCommand:
                 self.action_filters = None
                 raise EESSIBotCommandError("invalid action filter")
             except Exception as err:
-                log(f"Unexpected {err=}, {type(err)=}")
+                log(f"Unexpected err={err}, type(err)={type(err)}")
                 raise
         else:
             self.action_filters = EESSIBotActionFilter("")

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -1,0 +1,33 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+import re
+import sys
+
+from pyghee.utils import log
+
+
+def get_bot_command(line):
+    """
+        Retrieve bot command from a line.
+    Args:
+        line (string): string that is scanned for a command
+
+    Returns:
+        command (string): the command if any found or None
+    """
+    fn = sys._getframe().f_code.co_name
+
+    log(f"{fn}(): searching for bot command in '{line}'")
+    match = re.search('^bot: (.*)$', line)
+    if match:
+        return match.group(1).rstrip()
+    else:
+        return None

--- a/tools/filter.py
+++ b/tools/filter.py
@@ -38,7 +38,7 @@ class EESSIBotActionFilter:
             except EESSIBotActionFilterError:
                 raise
             except Exception as err:
-                log(f"Unexpected {err=}, {type(err)=}")
+                log(f"Unexpected err={err}, type(err)={type(err)}")
                 raise
 
     def clear_all(self):
@@ -66,7 +66,7 @@ class EESSIBotActionFilter:
             self.action_filters.append(Filter(full_component, pattern))
         else:
             log(f"component {component} is unknown")
-            raise EESSIBotActionFilterError(f"unknown {component=} in {component}:{pattern}")
+            raise EESSIBotActionFilterError(f"unknown component={component} in {component}:{pattern}")
 
     def add_filter_from_string(self, filter_string):
         """

--- a/tools/job_metadata.py
+++ b/tools/job_metadata.py
@@ -1,0 +1,72 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+from collections import namedtuple
+import configparser
+import os
+import sys
+
+from pyghee.utils import log, error
+from tasks.build import Job
+
+
+def create_metadata_file(job, job_id, pr, pr_comment_id):
+    """Create metadata file in submission dir.
+
+    Args:
+        job (named tuple): key data about job that has been submitted
+        job_id (string): id of submitted job
+        pr (github.PullRequest.Pullrequest): object to interact with pull request
+        pr_comment_id (int): id of PR comment
+    """
+    fn = sys._getframe().f_code.co_name
+
+    repo_name = pr.base.repo.full_name
+
+    # create _bot_job<jobid>.metadata file in submission directory
+    bot_jobfile = configparser.ConfigParser()
+    bot_jobfile['PR'] = {'repo': repo_name, 'pr_number': pr.number, 'pr_comment_id': pr_comment_id}
+    bot_jobfile_path = os.path.join(job.working_dir, f'_bot_job{job_id}.metadata')
+    with open(bot_jobfile_path, 'w') as bjf:
+        bot_jobfile.write(bjf)
+    log(f"{fn}(): created job metadata file {bot_jobfile_path}")
+
+
+def read_metadata_file(job_metadata_path, log_file=None):
+    """
+    Try to read metadata file and return its PR section. Return None in
+    case of failure (treat all cases as if the file did not exist):
+    - file does not exist,
+    - file exists but does not contain PR section,
+    - file exists but parsing/reading resulted in an exception.
+
+    Args:
+        job_metadata_path (string): path to job metadata file
+        log_file (string): path to log file
+    """
+    # check if metadata file exist
+    if os.path.isfile(job_metadata_path):
+        log(f"Found metadata file at {job_metadata_path}", log_file)
+        metadata = configparser.ConfigParser()
+        try:
+            metadata.read(job_metadata_path)
+        except Exception as err:
+            # error would let the process exist, this is too harsh,
+            log(f"Unable to read job metadata file {job_metadata_path}: {err}")
+            return None
+
+        # get PR section
+        if "PR" in metadata:
+            return metadata["PR"]
+        else:
+            return None
+    else:
+        log(f"No metadata file found at {job_metadata_path}, so not a bot job", log_file)
+        return None

--- a/tools/job_metadata.py
+++ b/tools/job_metadata.py
@@ -39,34 +39,30 @@ def create_metadata_file(job, job_id, pr, pr_comment_id):
     log(f"{fn}(): created job metadata file {bot_jobfile_path}")
 
 
-def read_metadata_file(job_metadata_path, log_file=None):
+def read_metadata_file(metadata_path, log_file=None):
     """
-    Try to read metadata file and return its PR section. Return None in
+    Try to read metadata file and return it. Return None in
     case of failure (treat all cases as if the file did not exist):
     - file does not exist,
-    - file exists but does not contain PR section,
     - file exists but parsing/reading resulted in an exception.
 
     Args:
-        job_metadata_path (string): path to job metadata file
+        metadata_path (string): path to metadata file
         log_file (string): path to log file
     """
     # check if metadata file exist
-    if os.path.isfile(job_metadata_path):
-        log(f"Found metadata file at {job_metadata_path}", log_file)
+    if os.path.isfile(metadata_path):
+        log(f"Found metadata file at {metadata_path}", log_file)
         metadata = configparser.ConfigParser()
         try:
-            metadata.read(job_metadata_path)
+            metadata.read(metadata_path)
         except Exception as err:
             # error would let the process exist, this is too harsh,
-            log(f"Unable to read job metadata file {job_metadata_path}: {err}")
+            # we return None and let the caller decide what to do.
+            log(f"Unable to read metadata file {metadata_path}: {err}")
             return None
 
-        # get PR section
-        if "PR" in metadata:
-            return metadata["PR"]
-        else:
-            return None
+        return metadata
     else:
-        log(f"No metadata file found at {job_metadata_path}, so not a bot job", log_file)
+        log(f"No metadata file found at {metadata_path}.", log_file)
         return None

--- a/tools/job_metadata.py
+++ b/tools/job_metadata.py
@@ -8,31 +8,35 @@
 #
 # license: GPLv2
 #
-from collections import namedtuple
+# from collections import namedtuple
 import configparser
 import os
 import sys
 
 from pyghee.utils import log, error
 from tasks.build import Job
+from tools.pr_comments import PRComment
 
 
-def create_metadata_file(job, job_id, pr, pr_comment_id):
+def create_metadata_file(job, job_id, pr_comment):
     """Create metadata file in submission dir.
 
     Args:
         job (named tuple): key data about job that has been submitted
         job_id (string): id of submitted job
-        pr (github.PullRequest.Pullrequest): object to interact with pull request
-        pr_comment_id (int): id of PR comment
+        pr_comment (PRComment): contains repo_name, pr_number and pr_comment_id
     """
     fn = sys._getframe().f_code.co_name
 
-    repo_name = pr.base.repo.full_name
+    repo_name = pr_comment.repo_name
+    pr_number = pr_comment.pr_number
+    pr_comment_id = pr_comment.pr_comment_id
 
     # create _bot_job<jobid>.metadata file in submission directory
     bot_jobfile = configparser.ConfigParser()
-    bot_jobfile['PR'] = {'repo': repo_name, 'pr_number': pr.number, 'pr_comment_id': pr_comment_id}
+    bot_jobfile['PR'] = {'repo': repo_name,
+                         'pr_number': pr_number,
+                         'pr_comment_id': pr_comment_id}
     bot_jobfile_path = os.path.join(job.working_dir, f'_bot_job{job_id}.metadata')
     with open(bot_jobfile_path, 'w') as bjf:
         bot_jobfile.write(bjf)

--- a/tools/job_metadata.py
+++ b/tools/job_metadata.py
@@ -13,9 +13,9 @@ import configparser
 import os
 import sys
 
-from pyghee.utils import log, error
-from tasks.build import Job
-from tools.pr_comments import PRComment
+from pyghee.utils import log
+# from tasks.build import Job
+# from tools.pr_comments import PRComment
 
 
 def create_metadata_file(job, job_id, pr_comment):

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -17,17 +17,16 @@ BOT_CONTROL = "bot_control"
 COMMAND_PERMISSION = "command_permission"
 
 
-def check_command_permission(pr, event_info):
+def check_command_permission(account):
     """check if the GH account is authorized to send commands to the bot
 
     Args:
-        pr (object): pr details
-        event_info (string): event received by event_handler
+        account (string): account for which permissions shall be checked
 
     """
     fn = sys._getframe().f_code.co_name
 
-    log(f"{fn}(): checking permission for sending commands for PR {pr.number}")
+    log(f"{fn}(): checking permission for sending commands")
 
     cfg = config.read_config()
 
@@ -39,10 +38,9 @@ def check_command_permission(pr, event_info):
 
     log(f"{fn}(): command permission '{command_permission}'")
 
-    event_sender = event_info['raw_request_body']['sender']['login']
-    if event_sender not in command_permission.split():
-        log(f"{fn}(): GH account '{event_sender}' is not authorized to send commands to the bot instance")
+    if account not in command_permission.split():
+        log(f"{fn}(): GH account '{account}' is not authorized to send commands to the bot instance")
         return False
     else:
-        log(f"{fn}(): GH account '{event_sender}' is authorized to send commands")
+        log(f"{fn}(): GH account '{account}' is authorized to send commands")
         return True

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -1,0 +1,48 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+import sys
+
+from pyghee.utils import log
+from tools import config
+
+BOT_CONTROL = "bot_control"
+COMMAND_PERMISSION = "command_permission"
+
+
+def check_command_permission(pr, event_info):
+    """check if the GH account is authorized to send commands to the bot
+
+    Args:
+        pr (object): pr details
+        event_info (string): event received by event_handler
+
+    """
+    fn = sys._getframe().f_code.co_name
+
+    log(f"{fn}(): checking permission for sending commands for PR {pr.number}")
+
+    cfg = config.read_config()
+
+    bot_ctrl = cfg[BOT_CONTROL]
+
+    # verify that the GH account that has sent a command (via a adding or editing
+    # a comment) has the permission to control the bot
+    command_permission = bot_ctrl.get(COMMAND_PERMISSION, '')
+
+    log(f"{fn}(): command permission '{command_permission}'")
+
+    event_sender = event_info['raw_request_body']['sender']['login']
+    if event_sender not in command_permission.split():
+        log(f"{fn}(): GH account '{event_sender}' is not authorized to send commands to the bot instance")
+        return False
+    else:
+        log(f"{fn}(): GH account '{event_sender}' is authorized to send commands")
+        return True

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -38,9 +38,9 @@ def check_command_permission(account):
 
     log(f"{fn}(): command permission '{command_permission}'")
 
-    if account not in command_permission.split():
-        log(f"{fn}(): GH account '{account}' is not authorized to send commands to the bot instance")
-        return False
-    else:
+    if account in command_permission.split():
         log(f"{fn}(): GH account '{account}' is authorized to send commands")
         return True
+    else:
+        log(f"{fn}(): GH account '{account}' is not authorized to send commands to the bot instance")
+        return False

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -13,10 +13,14 @@
 #
 import re
 
+from collections import namedtuple
 from connections import github
 from pyghee.utils import log
 from retry import retry
 from retry.api import retry_call
+
+
+PRComment = namedtuple('PRComment', ('repo_name', 'pr_number', 'pr_comment_id'))
 
 
 @retry(Exception, tries=5, delay=1, backoff=2, max_delay=30)

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -116,5 +116,6 @@ def make_html_list_items(lines):
     """
     html_list_items = ""
     for line in lines.split("\n"):
-        html_list_items += f"<li>{line}</li>"
+        if len(line.strip()) > 0:
+            html_list_items += f"<li>{line}</li>"
     return html_list_items

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -103,3 +103,18 @@ def update_pr_comment(event_info, update):
     pull_request = repo.get_pull(pr_number)
     issue_comment = pull_request.get_issue_comment(issue_id)
     issue_comment.edit(comment_new + update)
+
+
+def make_html_list_items(lines):
+    """Makes HTML list from lines.
+
+    Args:
+        lines (string): multiline string
+
+    Returns:
+        multiline (string): formatted as HTML list items
+    """
+    html_list_items = ""
+    for line in lines.split("\n"):
+        html_list_items += f"<li>{line}</li>"
+    return html_list_items


### PR DESCRIPTION
PR on top of #172 to improve analysing the result of a bot job. It intends to move any repository specific code to the target repository (what the bot is used to build for). The two major changes are
- letting the main job script run the script `bot/check-result.sh` provided by the target repository (e.g., EESSI/software-layer or EESSI/compatibility-layer or any other "software" repository)
- letting the job manager's `process_finished_job` function use a result file produced by the above `check-result.sh` script to update a comment in the PR with a `SUCCESS/FAILURE/UNKNOWN` message and detailed information

At the moment, the code still includes the old method for analysing a job's result. Once the software-layer and compatibility-layer repositories have been updated to provide `bot/check-result.sh` script this can be removed. A draft version of such a script is included in https://github.com/EESSI/compatibility-layer/pull/179