### PR TITLE
some fixes for letting the job manager handle non bot jobs correctly 

### DIFF
--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -676,6 +676,10 @@ def main():
             #        " %s due to parameter '--jobs %s'" % (
             #          nj,opts.jobs), job_manager.logfile)
 
+        # remove non bot jobs from current_jobs
+        for job in non_bot_jobs:
+            current_jobs.pop(job)
+
         running_jobs = job_manager.determine_running_jobs(current_jobs)
         log(
             "job manager main loop: running_jobs='%s'" %
@@ -685,7 +689,7 @@ def main():
 
         for rj in running_jobs:
             if not job_manager.job_filter or rj in job_manager.job_filter:
-                job_manager.process_running_jobs(known_jobs[rj])
+                job_manager.process_running_jobs(current_jobs[rj])
 
         finished_jobs = job_manager.determine_finished_jobs(
                         known_jobs, current_jobs)
@@ -702,10 +706,6 @@ def main():
             #    log("job manager main loop: skipping finished "
             #        "job %s due"" to parameter '--jobs %s'" % (fj,opts.jobs),
             #        " job_manager.logfile)"
-
-        # remove non bot jobs from current_jobs
-        for job in non_bot_jobs:
-            current_jobs.pop(job)
 
         known_jobs = current_jobs
 


### PR DESCRIPTION
- need to remove non bot jobs earlier, because
  - `process_running_jobs()` does not double-check if a job is a bot's job or not
  - current jobs are determined via `squeue` so could include non bot jobs (again for every iteration) 
- using current jobs for processing running jobs instead of known jobs
  - a running job may not yet be in the list of known jobs (that is created at the start or in the last iteration)
  - when the current jobs are used we need to make sure it only includes bot jobs (therefore non bot jobs need to be removed from the list as early as possible)

- somewhat tested with recent jobs to build compat layer (and discovered while running interactive debug sessions)