### PR TITLE
replay a GitHub event locally at a bot instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ appbackup.cfg
 venv_bot_p37
 *.swo
 events_log/
+event_links/
+venv

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -120,6 +120,7 @@ arch_target_map = { "linux/x86_64/generic" : "--constraint shape=c4.2xlarge", "l
 [event_handler]
 # path to the log file to log messages for event handler
 log_path = /path/to/eessi_bot_event_handler.log
+event_links_path = /path/to/event_links
 
 
 [job_manager]

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -152,7 +152,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         """
         event = namedtuple('Request', ['headers', 'json', 'data'])
 
-        for (dir, subdirs, files) in os.walk("."):
+        for (dir, _subdirs, files) in os.walk("."):
             if any([event_id in file for file in files]):
                 with open(f"{dir}/{event_id}_headers.json", 'r') as jf:
                     headers = json.load(jf)
@@ -160,7 +160,7 @@ class EESSIBotSoftwareLayer(PyGHee):
                 with open(f"{dir}/{event_id}_body.json", 'r') as jf:
                     body = json.load(jf)
                     event.json = body
-        
+
         event_info = get_event_info(event)
         self.handle_event(event_info)
 

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -26,7 +26,7 @@ from tools.args import event_handler_parse
 from tasks.build import check_build_permission, submit_build_jobs, get_repo_cfg
 from tasks.deploy import deploy_built_artefacts
 
-from pyghee.lib import PyGHee, create_app, get_event_info, read_event_from_json
+from pyghee.lib import PyGHee, create_app
 from pyghee.utils import log
 
 

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -10,6 +10,7 @@
 # author: Bob Droege (@bedroge)
 # author: Hafsa Naeem (@hafsa-naeem)
 # author: Thomas Roeblitz (@trz42)
+# author: Jonas Qvigstad (@jonas-lq)
 #
 # license: GPLv2
 #
@@ -153,7 +154,7 @@ class EESSIBotSoftwareLayer(PyGHee):
 
         event_log_fn = '%sT%s_%s' % (event_date, event_info['time'], event_id)
         event_log_path = os.path.join(events_log_dir, event_type, event_action, event_date, event_log_fn)
-        
+
         event_links_dir = config.read_config()[EVENT_HANDLER][EVENT_LINKS_PATH] + "/event_links"
         if not os.path.exists(event_links_dir):
             os.makedirs(event_links_dir)

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -24,6 +24,7 @@
 # author: Hafsa Naeem (@hafsa-naeem)
 # author: Jacob Ziemke (@jacobz137)
 # author: Thomas Roeblitz (@trz42)
+# author: Jonas Qvigstad (@jonas-lq)
 #
 # license: GPLv2
 #

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -8,6 +8,7 @@
 # author: Bob Droege (@bedroge)
 # author: Hafsa Naeem (@hafsa-naeem)
 # author: Thomas Roeblitz (@trz42)
+# author: Jonas Qvigstad (@jonas-lq)
 #
 # license: GPLv2
 #

--- a/tools/config.py
+++ b/tools/config.py
@@ -5,6 +5,7 @@
 # EESSI software layer, see https://github.com/EESSI/software-layer
 #
 # author: Bob Droege (@bedroge)
+# author: Jonas Qvigstad (@jonas-lq)
 #
 # license: GPLv2
 #

--- a/tools/replay_events.py
+++ b/tools/replay_events.py
@@ -7,22 +7,22 @@ from requests.structures import CaseInsensitiveDict
 
 
 def replay_event(app, event_id):
-        """Replay an event stored in the file system
+    """Replay an event stored in the file system
 
-        Args:
-            app (EESSIBotSoftwareLayer): the app that is supposed to handle the event
-            event_id (string): The id of the event that should be replayed
-        """
-        event = namedtuple('Request', ['headers', 'json', 'data'])
+    Args:
+        app (EESSIBotSoftwareLayer): the app that is supposed to handle the event
+        event_id (string): The id of the event that should be replayed
+    """
+    event = namedtuple('Request', ['headers', 'json', 'data'])
 
-        for (dir, _subdirs, files) in os.walk("events_log"):
-            if any([event_id in file for file in files]):
-                with open(f"{dir}/{event_id}_headers.json", 'r') as jf:
-                    headers = json.load(jf)
-                    event.headers = CaseInsensitiveDict(headers)
-                with open(f"{dir}/{event_id}_body.json", 'r') as jf:
-                    body = json.load(jf)
-                    event.json = body
+    for (dir, _subdirs, files) in os.walk("events_log"):
+        if any([event_id in file for file in files]):
+            with open(f"{dir}/{event_id}_headers.json", 'r') as jf:
+                headers = json.load(jf)
+                event.headers = CaseInsensitiveDict(headers)
+            with open(f"{dir}/{event_id}_body.json", 'r') as jf:
+                body = json.load(jf)
+                event.json = body
 
-        event_info = get_event_info(event)
-        app.handle_event(event_info)
+    event_info = get_event_info(event)
+    app.handle_event(event_info)

--- a/tools/replay_events.py
+++ b/tools/replay_events.py
@@ -1,0 +1,28 @@
+import json
+import os
+
+from collections import namedtuple
+from pyghee.lib import get_event_info
+from requests.structures import CaseInsensitiveDict
+
+
+def replay_event(app, event_id):
+        """Replay an event stored in the file system
+
+        Args:
+            app (EESSIBotSoftwareLayer): the app that is supposed to handle the event
+            event_id (string): The id of the event that should be replayed
+        """
+        event = namedtuple('Request', ['headers', 'json', 'data'])
+
+        for (dir, _subdirs, files) in os.walk("events_log"):
+            if any([event_id in file for file in files]):
+                with open(f"{dir}/{event_id}_headers.json", 'r') as jf:
+                    headers = json.load(jf)
+                    event.headers = CaseInsensitiveDict(headers)
+                with open(f"{dir}/{event_id}_body.json", 'r') as jf:
+                    body = json.load(jf)
+                    event.json = body
+
+        event_info = get_event_info(event)
+        app.handle_event(event_info)

--- a/tools/replay_events.py
+++ b/tools/replay_events.py
@@ -1,9 +1,22 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Jonas Qvigstad (@jonas-lq)
+#
+# license: GPLv2
+#
 import json
-import os
 
 from collections import namedtuple
 from pyghee.lib import get_event_info
 from requests.structures import CaseInsensitiveDict
+from tools import config
+
+EVENT_HANDLER = "event_handler"
+EVENT_LINKS_PATH = "event_links_path"
 
 
 def replay_event(app, event_id):
@@ -14,15 +27,14 @@ def replay_event(app, event_id):
         event_id (string): The id of the event that should be replayed
     """
     event = namedtuple('Request', ['headers', 'json', 'data'])
+    events_dir = config.read_config()[EVENT_HANDLER][EVENT_LINKS_PATH] + "/event_links"
 
-    for (dir, _subdirs, files) in os.walk("events_log"):
-        if any([event_id in file for file in files]):
-            with open(f"{dir}/{event_id}_headers.json", 'r') as jf:
-                headers = json.load(jf)
-                event.headers = CaseInsensitiveDict(headers)
-            with open(f"{dir}/{event_id}_body.json", 'r') as jf:
-                body = json.load(jf)
-                event.json = body
+    with open(f"{events_dir}/{event_id}_headers.json", 'r') as jf:
+        headers = json.load(jf)
+        event.headers = CaseInsensitiveDict(headers)
+    with open(f"{events_dir}/{event_id}_body.json", 'r') as jf:
+        body = json.load(jf)
+        event.json = body
 
     event_info = get_event_info(event)
     app.handle_event(event_info)


### PR DESCRIPTION
Fixes #94 

PR for being able to replay events stored in the file system.

Triggered by commenting "replay <event id>" on the pr (Your GitHub app must subscribe to the event "Issue comment")

There were already some support for replaying events (see line 200 in `eessi_bot_event_handler.py`), but this is outdated and would not work even if the specified file contained both the header and body (PyGHee logs events as separate files for body and header). Should I change the code here to utilise my newly implemented function?