### PR TITLE
don't use non-existent fatal_error function in bot-build.slurm script

### DIFF
--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -27,5 +27,6 @@ if [ -f bot/build.sh ]; then
     echo "bot/build.sh script found in '${PWD}', so running it!"
     bot/build.sh
 else
-    fatal_error "could not find bot/build.sh script in '${PWD}'"
+    echo "could not find bot/build.sh script in '${PWD}'" >&2
+    exit 1
 fi


### PR DESCRIPTION
While testing against my fork of the `software-layer` that didn't include the `bot/build.sh` script yet, I ran into this cryptic job output:

```
Starting bot-build.slurm
/var/spool/slurmd/job04871/slurm_script: line 30: fatal_error: command not found
```

With this change, I'm getting a proper error message in the job output file:
```
Starting bot-build.slurm
could not find bot/build.sh script in /mnt/shared/home/boegel/eessi-bot-software-layer/jobs/2023.06/pr_24/event_40037150-03b7-11ee-9ebb-a0d8ae8b854a/run_000/linux_x86_64_intel_skylake_avx512/EESSI-pilot
```

`fatal_error` is a function defined by the `scripts/utils.sh` script in the `software-layer` repo, we shouldn't assume it available generally...