### PR TITLE
fix job manager crashes due to wrong value for pr_comment_id

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -570,14 +570,14 @@ def submit_job(job, cfg):
     return job_id, symlink
 
 
-def create_metadata_file(job, job_id, pr, pr_comment_id):
+def create_metadata_file(job, job_id, pr, pr_comment):
     """Create metadata file in submission dir.
 
     Args:
         job (named tuple): key data about job that has been submitted
         job_id (string): id of submitted job
         pr (github.PullRequest.Pullrequest): object to interact with pull request
-        pr_comment_id (int): id of PR comment
+        pr_comment (github.IssueComment.IssueComment): instance containing a PR comment
     """
     fn = sys._getframe().f_code.co_name
 
@@ -585,6 +585,7 @@ def create_metadata_file(job, job_id, pr, pr_comment_id):
 
     # create _bot_job<jobid>.metadata file in submission directory
     bot_jobfile = configparser.ConfigParser()
+    pr_comment_id = pr_comment.id if pr_comment else -1
     bot_jobfile['PR'] = {'repo': repo_name, 'pr_number': pr.number, 'pr_comment_id': pr_comment_id}
     bot_jobfile_path = os.path.join(job.working_dir, f'_bot_job{job_id}.metadata')
     with open(bot_jobfile_path, 'w') as bjf:
@@ -671,11 +672,11 @@ def submit_build_jobs(pr, event_info, action_filter):
         job_id, symlink = submit_job(job, cfg)
 
         # report submitted job
-        pr_comment_id = create_pr_comment(job, job_id, app_name, pr, gh, symlink)
-        job_id_to_comment_map[job_id] = pr_comment_id
+        pr_comment = create_pr_comment(job, job_id, app_name, pr, gh, symlink)
+        job_id_to_comment_map[job_id] = pr_comment
 
         # create _bot_job<jobid>.metadata file in submission directory
-        create_metadata_file(job, job_id, pr, pr_comment_id)
+        create_metadata_file(job, job_id, pr, pr_comment)
 
     # return f"created jobs: {', '.join(job_ids)}"
     return job_id_to_comment_map

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -411,10 +411,10 @@ def test_create_metadata_file(mocked_github, tmpdir):
     job_id = "123"
 
     repo_name = "test_repo"
-    pr_comment_id = 77
+    pr_comment = MockIssueComment("test_create_metadata_file", comment_id=77)
     repo = mocked_github.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
-    create_metadata_file(job, job_id, pr, pr_comment_id)
+    create_metadata_file(job, job_id, pr, pr_comment)
 
     expected_file = f"_bot_job{job_id}.metadata"
     expected_file_path = os.path.join(tmpdir, expected_file)
@@ -434,14 +434,14 @@ def test_create_metadata_file(mocked_github, tmpdir):
     job2 = Job(dir_does_not_exist, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id2 = "222"
     with pytest.raises(FileNotFoundError):
-        create_metadata_file(job2, job_id2, pr, pr_comment_id)
+        create_metadata_file(job2, job_id2, pr, pr_comment)
 
     # use directory without write permission
     dir_without_write_perm = os.path.join("/")
     job3 = Job(dir_without_write_perm, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id3 = "333"
     with pytest.raises(OSError):
-        create_metadata_file(job3, job_id3, pr, pr_comment_id)
+        create_metadata_file(job3, job_id3, pr, pr_comment)
 
     # disk quota exceeded (difficult to create and unlikely to happen because
     # partition where file is stored is usually very large)
@@ -450,7 +450,7 @@ def test_create_metadata_file(mocked_github, tmpdir):
     # job_id = None
     job4 = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id4 = None
-    create_metadata_file(job4, job_id4, pr, pr_comment_id)
+    create_metadata_file(job4, job_id4, pr, pr_comment)
 
     expected_file4 = f"_bot_job{job_id}.metadata"
     expected_file_path4 = os.path.join(tmpdir, expected_file4)
@@ -466,4 +466,4 @@ def test_create_metadata_file(mocked_github, tmpdir):
     job5 = Job(None, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
     job_id5 = "555"
     with pytest.raises(TypeError):
-        create_metadata_file(job5, job_id5, pr, pr_comment_id)
+        create_metadata_file(job5, job_id5, pr, pr_comment)

--- a/tests/test_tools_pr_comments.py
+++ b/tests/test_tools_pr_comments.py
@@ -24,12 +24,12 @@ from tools.pr_comments import (
 
 
 class MockIssueComment:
-    def __init__(self, body, edit_raises='0', edit_exception=Exception):
+    def __init__(self, body, edit_raises='0', edit_exception=Exception, comment_id=1):
         self.body = body
         self.edit_raises = edit_raises
         self.edit_exception = edit_exception
         self.edit_call_count = 0
-        self.id = 1
+        self.id = comment_id
 
     def edit(self, body):
         def should_raise_exception():


### PR DESCRIPTION
This should fix recently observed job manager crashes (after #172 got merged and bot instances were updated)

- create_metadata_file receives a IssueComment instance, hence must get the id from that and add it to the metadata file (before it received the id)
- tests were adjusted to take the new interface into account