### PR TITLE
prefer bot/check-build.sh script over bot/check-result.sh in build job script

### DIFF
--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -429,7 +429,7 @@ class EESSIBotSoftwareLayerJobManager:
         os.rename(old_symlink, new_symlink)
 
         # REPORT status (to logfile in any case, to PR comment if accessible)
-        #   rely fully on what bot/check-result.sh has returned
+        #   rely fully on what bot/check-build.sh has returned
         #   check if file _bot_jobJOBID.result exists --> if so read it and
         #   update PR comment
         # contents of *.result file (here we only use section [RESULT])

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -32,12 +32,20 @@ else
     exit 1
 fi
 echo "bot/build.sh finished"
-CHECK_RESULT_SCRIPT=bot/check-result.sh
-if [ -f ${CHECK_RESULT_SCRIPT} ]; then
-    echo "${CHECK_RESULT_SCRIPT} script found in '${PWD}', so running it!"
-    ${CHECK_RESULT_SCRIPT}
+CHECK_BUILD_SCRIPT=bot/check-build.sh
+
+# temporarily also still consider bot/check-result.sh script as a fallback
+CHECK_RESULT_SCRIPT=bot/check-results.sh
+if [ ! -f ${CHECK_BUILD_SCRIPT} ] && [ -f ${CHECK_RESULT_SCRIPT} ]; then
+    echo "${CHECK_BUILD_SCRIPT} not found in ${PWD}, but ${CHECK_RESULT_SCRIPT} is found, so using that as fallback..."
+    CHECK_BUILD_SCRIPT=${CHECK_RESULT_SCRIPT}
+fi
+
+if [ -f ${CHECK_BUILD_SCRIPT} ]; then
+    echo "${CHECK_BUILD_SCRIPT} script found in '${PWD}', so running it!"
+    ${CHECK_BUILD_SCRIPT}
 else
-    echo "could not find ${CHECK_RESULT_SCRIPT} script in '${PWD}' ..."
+    echo "could not find ${CHECK_BUILD_SCRIPT} script in '${PWD}' ..."
     echo "... depositing default _bot_job${SLURM_JOB_ID}.result file in '${PWD}'"
     cat << 'EOF' > _bot_job${SLURM_JOB_ID}.result
 [RESULT]

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -33,14 +33,6 @@ else
 fi
 echo "bot/build.sh finished"
 CHECK_BUILD_SCRIPT=bot/check-build.sh
-
-# temporarily also still consider bot/check-result.sh script as a fallback
-CHECK_RESULT_SCRIPT=bot/check-results.sh
-if [ ! -f ${CHECK_BUILD_SCRIPT} ] && [ -f ${CHECK_RESULT_SCRIPT} ]; then
-    echo "${CHECK_BUILD_SCRIPT} not found in ${PWD}, but ${CHECK_RESULT_SCRIPT} is found, so using that as fallback..."
-    CHECK_BUILD_SCRIPT=${CHECK_RESULT_SCRIPT}
-fi
-
 if [ -f ${CHECK_BUILD_SCRIPT} ]; then
     echo "${CHECK_BUILD_SCRIPT} script found in '${PWD}', so running it!"
     ${CHECK_BUILD_SCRIPT}


### PR DESCRIPTION
While writing the [documentation for the bot](https://www.eessi.io/docs/bot/), I realized that `check-result.sh` is a bit of a misnomer, since eventually we may also want a `check-test.sh` and `check-deploy.sh` script.

By still considering `check-result.sh` as a fallback when `check-build.sh` is not there, we can transition easily to `check-build.sh` without causing trouble...