### PR TITLE
add support for specifying path to build logs directory

### DIFF
--- a/app.cfg.example
+++ b/app.cfg.example
@@ -49,6 +49,9 @@ command_response_fmt =
 # name of the job script used for building an EESSI stack
 build_job_script = PATH_TO_EESSI_BOT/scripts/bot-build.slurm
 
+# Path (directory) to which build logs for (only) failing builds should be copied by bot/build.sh script
+build_logs_dir = PATH_TO_BUILD_LOGS_DIR
+
 #The container_cachedir may be used to reuse downloaded container image files
 #across jobs. Thus, jobs can more quickly launch containers.
 container_cachedir = PATH_TO_SHARED_DIRECTORY

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -29,6 +29,7 @@ APP_NAME = "app_name"
 AWAITS_RELEASE = "awaits_release"
 BUILDENV = "buildenv"
 BUILD_JOB_SCRIPT = "build_job_script"
+BUILD_LOGS_DIR = "build_logs_dir"
 CONTAINER_CACHEDIR = "container_cachedir"
 DEFAULT_JOB_TIME_LIMIT = "24:00:00"
 CVMFS_CUSTOMIZATIONS = "cvmfs_customizations"
@@ -114,6 +115,10 @@ def get_build_env_cfg(cfg):
     container_cachedir = buildenv.get(CONTAINER_CACHEDIR)
     log(f"{fn}(): container_cachedir '{container_cachedir}'")
     config_data[CONTAINER_CACHEDIR] = container_cachedir
+
+    build_logs_dir = buildenv.get(BUILD_LOGS_DIR)
+    log(f"{fn}(): build_logs_dir '{build_logs_dir}'")
+    config_data[BUILD_LOGS_DIR] = build_logs_dir
 
     cvmfs_customizations = {}
     try:
@@ -452,6 +457,7 @@ def prepare_job_cfg(job_dir, build_env_cfg, repos_cfg, repo_id, software_subdir,
     # create ini file job.cfg with entries:
     # [site_config]
     # local_tmp = LOCAL_TMP_VALUE
+    # build_logs_dir = BUILD_LOGS_DIR
     #
     # [repository]
     # repos_cfg_dir = JOB_CFG_DIR
@@ -475,6 +481,8 @@ def prepare_job_cfg(job_dir, build_env_cfg, repos_cfg, repo_id, software_subdir,
         job_cfg[JOB_SITECONFIG][JOB_HTTPS_PROXY] = build_env_cfg[HTTPS_PROXY]
     if build_env_cfg[LOAD_MODULES]:
         job_cfg[JOB_SITECONFIG][JOB_LOAD_MODULES] = build_env_cfg[LOAD_MODULES]
+    if build_env_cfg[BUILD_LOGS_DIR]:
+        job_cfg[JOB_SITECONFIG][BUILD_LOGS_DIR] = build_env_cfg[BUILD_LOGS_DIR]
 
     job_cfg[JOB_REPOSITORY] = {}
     # directory for repos.cfg


### PR DESCRIPTION
Add support for specifying path to build logs directory, to which `bot/build.sh` script should copy build log for failing builds.

This way, contributors can access the build log of failing builds, if they have an account on the Slurm cluster where the bot is running and is configured with `build_logs_dir` set to a readable directory on a shared filesystem.