### PR TITLE
add support to run test suite at the end of a build job

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `
 `multiple_tarballs` is used to report that multiple tarballs have been found.
 
 ```
-job_result_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for details)_</summary><ul><li>Job results file `{filename}` does not exist in job directory or reading it failed.</li><li>No artefacts were found/reported.</li></ul></details>
+job_result_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for details)_</summary><ul><li>Job results file `{filename}` does not exist in job directory, or parsing it failed.</li><li>No artefacts were found/reported.</li></ul></details>
 ```
 `job_result_unknown_fmt` is used in case no result file (produced by `bot/check-build.sh`
 provided by target repository) was found.

--- a/README.md
+++ b/README.md
@@ -600,6 +600,12 @@ job_result_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for 
 `job_result_unknown_fmt` is used in case no result file (produced by `bot/check-build.sh`
 provided by target repository) was found.
 
+```
+job_test_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for details)_</summary><ul><li>Job test file `{filename}` does not exist in job directory or reading it failed.</li></ul></details>
+```
+`job_test_unknown_fmt` is used in case no test file (produced by `bot/check-test.sh`
+provided by target repository) was found.
+
 # Instructions to run the bot components
 
 The bot consists of three components:

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -215,3 +215,4 @@ no_tarball_message = Slurm output lacks message about created tarball.
 no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir.
 multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected.
 job_result_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for detailed information)_<summary/><ul><li>Job results file `{filename}` does not exist in job directory or reading it failed.</li><li>No artefacts were found/reported.</li></ul></details>
+job_test_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for detailed information)_<summary/><ul><li>Job test file `{filename}` does not exist in job directory or reading it failed.</li></ul></details>

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -301,7 +301,7 @@ class EESSIBotSoftwareLayerJobManager:
         # reuse function from module tools.job_metadata to read metadata file
         test = read_metadata_file(job_test_file_path, self.logfile)
         if test and "TEST" in test:
-            return result["TEST"]
+            return test["TEST"]
         else:
             return None
 

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -51,6 +51,8 @@ FAILURE = "failure"
 FINISHED_JOB_COMMENTS = "finished_job_comments"
 JOB_RESULT_COMMENT_DESCRIPTION = "comment_description"
 JOB_RESULT_UNKNOWN_FMT = "job_result_unknown_fmt"
+JOB_TEST_COMMENT_DESCRIPTION = "comment_description"
+JOB_TEST_UNKNOWN_FMT = "job_test_unknown_fmt"
 MISSING_MODULES = "missing_modules"
 MULTIPLE_TARBALLS = "multiple_tarballs"
 NEW_JOB_COMMENTS = "new_job_comments"
@@ -285,6 +287,24 @@ class EESSIBotSoftwareLayerJobManager:
         else:
             return None
 
+    def read_job_test(self, job_test_file_path):
+        """
+        Read job test file and return the contents of the 'TEST' section.
+
+        Args:
+            job_test_file_path (string): path to job test file
+
+        Returns:
+            (ConfigParser): instance of ConfigParser corresponding to the
+                'TEST' section or None
+        """
+        # reuse function from module tools.job_metadata to read metadata file
+        test = read_metadata_file(job_test_file_path, self.logfile)
+        if test and "TEST" in test:
+            return result["TEST"]
+        else:
+            return None
+
     def process_new_job(self, new_job):
         """
         Process a new job by verifying that it is a bot job and if so
@@ -470,7 +490,8 @@ class EESSIBotSoftwareLayerJobManager:
         """
         Process a finished job by
         - moving the symlink to the directory storing finished jobs,
-        - updating the PR comment with information from '*.result' file
+        - updating the PR comment with information from '*.result' and '*.test'
+          files
 
         Args:
             finished_job (dict): dictionary with information about the job
@@ -497,14 +518,21 @@ class EESSIBotSoftwareLayerJobManager:
         os.rename(old_symlink, new_symlink)
 
         # REPORT status (to logfile in any case, to PR comment if accessible)
-        #   rely fully on what bot/check-build.sh has returned
-        #   check if file _bot_jobJOBID.result exists --> if so read it and
-        #   update PR comment
-        # contents of *.result file (here we only use section [RESULT])
-        #   [RESULT]
-        #   comment_description = _FULLY_DEFINED_UPDATE_TO_PR_COMMENT_
-        #   status = {SUCCESS,FAILURE,UNKNOWN}
-        #   artefacts = _LIST_OF_ARTEFACTS_TO_BE_DEPLOYED_
+        #  - rely fully on what bot/check-build.sh and bot/check-test.sh have
+        #    returned
+        #  - check if file _bot_jobJOBID.result exists --> if so read it and
+        #    update PR comment
+        #    . contents of *.result file (here we only use section [RESULT])
+        #      [RESULT]
+        #      comment_description = _FULLY_DEFINED_UPDATE_TO_PR_COMMENT_
+        #      status = {SUCCESS,FAILURE,UNKNOWN}
+        #      artefacts = _LIST_OF_ARTEFACTS_TO_BE_DEPLOYED_
+        #  - check if file _bot_jobJOBID.test exists --> if so read it and
+        #    update PR comment
+        #    . contents of *.test file (here we only use section [TEST])
+        #      [TEST]
+        #      comment_description = _FULLY_DEFINED_UPDATE_TO_PR_COMMENT_
+        #      status = {SUCCESS,FAILURE,UNKNOWN}
 
         # obtain format templates from app.cfg
         finished_job_comments_cfg = config.read_config()[FINISHED_JOB_COMMENTS]
@@ -531,6 +559,33 @@ class EESSIBotSoftwareLayerJobManager:
         dt = datetime.now(timezone.utc)
 
         comment_update = f"\n|{dt.strftime('%b %d %X %Z %Y')}|finished|"
+        comment_update += f"{comment_description}|"
+
+        # check if _bot_jobJOBID.test exits
+        # TODO if not found, assume test was not run (or failed, or ...) and add
+        # a message noting that ('not tested' + 'test suite not run or failed')
+        # --> 'bot: test [FILTERs]' command runs tests when filter matches
+        job_test_file = f"_bot_job{job_id}.test"
+        job_test_file_path = os.path.join(new_symlink, job_test_file)
+        job_tests = self.read_job_test(job_test_file_path)
+
+        job_test_unknown_fmt = finished_job_comments_cfg[JOB_TEST_UNKNOWN_FMT]
+        # set fallback comment_description in case no test file was found
+        # (self.read_job_result returned None)
+        comment_description = job_test_unknown_fmt.format(filename=job_test_file)
+        if job_tests:
+            # get preformatted comment_description or use previously set default for unknown
+            comment_description = job_tests.get(JOB_TEST_COMMENT_DESCRIPTION, comment_description)
+
+        # report to log
+        log(f"{fn}(): finished job {job_id}, test suite result\n"
+            f"########\n"
+            f"comment_description: {comment_description}\n"
+            f"########\n", self.logfile)
+
+        dt = datetime.now(timezone.utc)
+
+        comment_update += f"\n|{dt.strftime('%b %d %X %Z %Y')}|tested|"
         comment_update += f"{comment_description}|"
 
         # obtain id of PR comment to be updated (from file '_bot_jobID.metadata')

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -46,7 +46,7 @@ status = UNKNOWN
 artefacts =
 EOF
 fi
-echo "check result step finished"
+echo "check build step finished"
 TEST_SCRIPT=bot/test.sh
 if [ -f ${TEST_SCRIPT} ]; then
     echo "${TEST_SCRIPT} script found in '${PWD}', so running it!"

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -47,3 +47,26 @@ artefacts =
 EOF
 fi
 echo "check result step finished"
+TEST_SCRIPT=bot/test.sh
+if [ -f ${TEST_SCRIPT} ]; then
+    echo "${TEST_SCRIPT} script found in '${PWD}', so running it!"
+    ${TEST_SCRIPT}
+    echo "${TEST_SCRIPT} finished"
+else
+    echo "could not find ${TEST_SCRIPT} script in '${PWD}'" >&2
+fi
+CHECK_TEST_SCRIPT=bot/check-test.sh
+if [ -f ${CHECK_TEST_SCRIPT} ]; then
+    echo "${CHECK_TEST_SCRIPT} script found in '${PWD}', so running it!"
+    ${CHECK_TEST_SCRIPT}
+else
+    echo "could not find ${CHECK_TEST_SCRIPT} script in '${PWD}' ..."
+    echo "... depositing default _bot_job${SLURM_JOB_ID}.test file in '${PWD}'"
+    cat << 'EOF' > _bot_job${SLURM_JOB_ID}.test
+[RESULT]
+comment_description = <details><summary>:shrug: UNKNOWN _(click triangle for detailed information)_<summary/><ul><li>Did not find `bot/check-test.sh` script in job's work directory.</li><li>*Check job manually or ask an admin of the bot instance to assist you.*</li></ul></details>
+status = UNKNOWN
+artefacts =
+EOF
+fi
+echo "check test step finished"


### PR DESCRIPTION
- Adds the necessary steps to the Slurm job script.
- Adds handling of the result of the test suite run (i.e., updating the PR comment).
- Adds one config setting `job_test_unknown_fmt` and corresponding description.

Also see accompanying PR for software-layer https://github.com/EESSI/software-layer/pull/366

edit (by @boegel): it's worth noting that these changes will require adding `job_test_unknown_fmt` to  the bot configuration file, or the job manager will crash with:
```
...
  File "/home/boegel/eessi-bot-software-layer/eessi_bot_job_manager.py", line 572, in process_finished_job
    job_test_unknown_fmt = finished_job_comments_cfg[JOB_TEST_UNKNOWN_FMT]
  File "/usr/lib64/python3.6/configparser.py", line 1233, in __getitem__
    raise KeyError(key)
KeyError: 'job_test_unknown_fmt'
```
when processing a finished job