### PR TITLE
remove references to 'pilot', switch to software.eessi.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,10 +473,10 @@ repos_cfg_dir = PATH_TO_SHARED_DIRECTORY/cfg_bundles
 The `repos.cfg` file also uses the `ini` format as follows
 ```ini
 [eessi-2023.06]
-repo_name = pilot.eessi-hpc.org
+repo_name = software.eessi.io
 repo_version = 2023.06
-config_bundle = eessi-hpc.org-cfg_files.tgz
-config_map = { "eessi-hpc.org/cvmfs-config.eessi-hpc.org.pub":"/etc/cvmfs/keys/eessi-hpc.org/cvmfs-config.eessi-hpc.org.pub", "eessi-hpc.org/ci.eessi-hpc.org.pub":"/etc/cvmfs/keys/eessi-hpc.org/ci.eessi-hpc.org.pub", "eessi-hpc.org/pilot.eessi-hpc.org.pub":"/etc/cvmfs/keys/eessi-hpc.org/pilot.eessi-hpc.org.pub", "default.local":"/etc/cvmfs/default.local", "eessi-hpc.org.conf":"/etc/cvmfs/domain.d/eessi-hpc.org.conf"}
+config_bundle = eessi.io-cfg_files.tgz
+config_map = {"eessi.io/cvmfs-config.eessi.io.pub":"/etc/cvmfs/keys/eessi.io/cvmfs-config.eessi.io.pub", "eessi.io/ci.eessi.io.pub":"/etc/cvmfs/keys/eessi.io/ci.eessi.io.pub", "eessi.io/software.eessi.io.pub":"/etc/cvmfs/keys/eessi.io/software.eessi.io.pub", "default.local":"/etc/cvmfs/default.local", "eessi.io.conf":"/etc/cvmfs/domain.d/eessi.io.conf"}
 container = docker://ghcr.io/eessi/build-node:debian11
 ```
 The repository id is given in brackets (`[eessi-2023.06]`). Then the name of the repository (`repo_name`) and the

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ The `repos.cfg` file also uses the `ini` format as follows
 repo_name = software.eessi.io
 repo_version = 2023.06
 config_bundle = eessi.io-cfg_files.tgz
-config_map = {"eessi.io/cvmfs-config.eessi.io.pub":"/etc/cvmfs/keys/eessi.io/cvmfs-config.eessi.io.pub", "eessi.io/ci.eessi.io.pub":"/etc/cvmfs/keys/eessi.io/ci.eessi.io.pub", "eessi.io/software.eessi.io.pub":"/etc/cvmfs/keys/eessi.io/software.eessi.io.pub", "default.local":"/etc/cvmfs/default.local", "eessi.io.conf":"/etc/cvmfs/domain.d/eessi.io.conf"}
+config_map = {"eessi.io/eessi.io.pub":"/etc/cvmfs/keys/eessi.io/eessi.io.pub", "default.local":"/etc/cvmfs/default.local", "eessi.io.conf":"/etc/cvmfs/domain.d/eessi.io.conf"}
 container = docker://ghcr.io/eessi/build-node:debian11
 ```
 The repository id is given in brackets (`[eessi-2023.06]`). Then the name of the repository (`repo_name`) and the

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -157,7 +157,7 @@ arch_target_map = { "linux/x86_64/generic" : "--constraint shape=c4.2xlarge", "l
 # EESSI/2021.12 and NESSI/2022.11
 repo_target_map = { "linux/x86_64/amd/zen2" : ["eessi-2021.12","nessi.no-2022.11"] }
 
-# points to definition of repositories (default EESSI-pilot defined by build container)
+# points to definition of repositories (default repository defined by build container)
 repos_cfg_dir = PATH_TO_SHARED_DIRECTORY/cfg_bundles
 
 

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -430,9 +430,9 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
             log(f"{fn}(): skipping arch {arch} because repo target map does not define repositories to build for")
             continue
         for repo_id in repocfg[REPO_TARGET_MAP][arch]:
-            # ensure repocfg contains information about the repository repo_id if repo_id != EESSI-pilot
-            # Note, EESSI-pilot is a bad/misleading name, it should be more like AS_IN_CONTAINER
-            if repo_id != "EESSI-pilot" and repo_id not in repocfg:
+            # ensure repocfg contains information about the repository repo_id if repo_id != EESSI
+            # Note, EESSI is a bad/misleading name, it should be more like AS_IN_CONTAINER
+            if repo_id != "EESSI" and repo_id not in repocfg:
                 log(f"{fn}(): skipping repo {repo_id}, it is not defined in repo config {repocfg[REPOS_CFG_DIR]}")
                 continue
 

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -432,7 +432,7 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
         for repo_id in repocfg[REPO_TARGET_MAP][arch]:
             # ensure repocfg contains information about the repository repo_id if repo_id != EESSI
             # Note, EESSI is a bad/misleading name, it should be more like AS_IN_CONTAINER
-            if repo_id != "EESSI" and repo_id not in repocfg:
+            if (repo_id != "EESSI" and repo_id != "EESSI-pilot") and repo_id not in repocfg:
                 log(f"{fn}(): skipping repo {repo_id}, it is not defined in repo config {repocfg[REPOS_CFG_DIR]}")
                 continue
 

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -280,7 +280,7 @@ def test_create_pr_comment_succeeds(mocked_github, tmpdir):
     print("CREATING PR COMMENT")
     ym = datetime.today().strftime('%Y.%m')
     pr_number = 1
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up", ym, pr_number)
+    job = Job(tmpdir, "test/architecture", "EESSI", "--speed-up", ym, pr_number)
 
     job_id = "123"
     app_name = "pytest"
@@ -309,7 +309,7 @@ def test_create_pr_comment_succeeds_none(mocked_github, tmpdir):
     print("CREATING PR COMMENT")
     ym = datetime.today().strftime('%Y.%m')
     pr_number = 1
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up", ym, pr_number)
+    job = Job(tmpdir, "test/architecture", "EESSI", "--speed-up", ym, pr_number)
 
     job_id = "123"
     app_name = "pytest"
@@ -334,7 +334,7 @@ def test_create_pr_comment_raises_once_then_succeeds(mocked_github, tmpdir):
     print("CREATING PR COMMENT")
     ym = datetime.today().strftime('%Y.%m')
     pr_number = 1
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up", ym, pr_number)
+    job = Job(tmpdir, "test/architecture", "EESSI", "--speed-up", ym, pr_number)
 
     job_id = "123"
     app_name = "pytest"
@@ -359,7 +359,7 @@ def test_create_pr_comment_always_raises(mocked_github, tmpdir):
     print("CREATING PR COMMENT")
     ym = datetime.today().strftime('%Y.%m')
     pr_number = 1
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up", ym, pr_number)
+    job = Job(tmpdir, "test/architecture", "EESSI", "--speed-up", ym, pr_number)
 
     job_id = "123"
     app_name = "pytest"
@@ -385,7 +385,7 @@ def test_create_pr_comment_three_raises(mocked_github, tmpdir):
     print("CREATING PR COMMENT")
     ym = datetime.today().strftime('%Y.%m')
     pr_number = 1
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed-up", ym, pr_number)
+    job = Job(tmpdir, "test/architecture", "EESSI", "--speed-up", ym, pr_number)
 
     job_id = "123"
     app_name = "pytest"
@@ -407,7 +407,7 @@ def test_create_read_metadata_file(mocked_github, tmpdir):
     # create some test data
     ym = datetime.today().strftime('%Y.%m')
     pr_number = 999
-    job = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
+    job = Job(tmpdir, "test/architecture", "EESSI", "--speed_up_job", ym, pr_number)
 
     job_id = "123"
 
@@ -438,14 +438,14 @@ def test_create_read_metadata_file(mocked_github, tmpdir):
 
     # use directory that does not exist
     dir_does_not_exist = os.path.join(tmpdir, "dir_does_not_exist")
-    job2 = Job(dir_does_not_exist, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
+    job2 = Job(dir_does_not_exist, "test/architecture", "EESSI", "--speed_up_job", ym, pr_number)
     job_id2 = "222"
     with pytest.raises(FileNotFoundError):
         create_metadata_file(job2, job_id2, pr_comment)
 
     # use directory without write permission
     dir_without_write_perm = os.path.join("/")
-    job3 = Job(dir_without_write_perm, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
+    job3 = Job(dir_without_write_perm, "test/architecture", "EESSI", "--speed_up_job", ym, pr_number)
     job_id3 = "333"
     with pytest.raises(OSError):
         create_metadata_file(job3, job_id3, pr_comment)
@@ -455,7 +455,7 @@ def test_create_read_metadata_file(mocked_github, tmpdir):
 
     # use undefined values for parameters
     # job_id = None
-    job4 = Job(tmpdir, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
+    job4 = Job(tmpdir, "test/architecture", "EESSI", "--speed_up_job", ym, pr_number)
     job_id4 = None
     create_metadata_file(job4, job_id4, pr_comment)
 
@@ -470,7 +470,7 @@ def test_create_read_metadata_file(mocked_github, tmpdir):
 
     # use undefined values for parameters
     # job.working_dir = None
-    job5 = Job(None, "test/architecture", "EESSI-pilot", "--speed_up_job", ym, pr_number)
+    job5 = Job(None, "test/architecture", "EESSI", "--speed_up_job", ym, pr_number)
     job_id5 = "555"
     with pytest.raises(TypeError):
         create_metadata_file(job5, job_id5, pr_comment)

--- a/tests/test_tools_filter.py
+++ b/tests/test_tools_filter.py
@@ -116,7 +116,7 @@ def test_match_architecture_job_context(complex_filter):
 
 
 def test_non_match_architecture_repository_context(complex_filter):
-    context = {"architecture": "x86_64/intel/cascadelake", "repository": "EESSI-pilot"}
+    context = {"architecture": "x86_64/intel/cascadelake", "repository": "EESSI"}
     expected = False
     actual = complex_filter.check_filters(context)
     assert expected == actual
@@ -132,7 +132,7 @@ def arch_filter_slash_syntax():
 
 
 def test_match_architecture_syntax_slash(arch_filter_slash_syntax):
-    context = {"architecture": "x86_64/intel/cascadelake", "repository": "EESSI-pilot"}
+    context = {"architecture": "x86_64/intel/cascadelake", "repository": "EESSI"}
     expected = True
     actual = arch_filter_slash_syntax.check_filters(context)
     assert expected == actual
@@ -153,7 +153,7 @@ def arch_filter_dash_syntax():
 
 
 def test_match_architecture_syntax_dash(arch_filter_dash_syntax):
-    context = {"architecture": "x86_64-intel-cascadelake", "repository": "EESSI-pilot"}
+    context = {"architecture": "x86_64-intel-cascadelake", "repository": "EESSI"}
     expected = True
     actual = arch_filter_dash_syntax.check_filters(context)
     assert expected == actual


### PR DESCRIPTION
Mostly changes in examples, README.md and tests. Only a single code file (`tasks/build.py`) had to be changed.

Implementation (use with bot instances) should be coordinated with software-layer PR https://github.com/EESSI/software-layer/pull/383