### PR TITLE
renew GitHub access token ahead of time to prevent "`Bad credentials`" crashes

### DIFF
--- a/connections/github.py
+++ b/connections/github.py
@@ -11,7 +11,7 @@
 #
 
 # Standard library imports
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import time
 
 # Third party imports (anything installed into the local Python environment)
@@ -99,8 +99,6 @@ def get_instance():
         Instance of Github
     """
     global _gh, _token
-    # TODO Possibly renew token already if expiry date is soon, not only
-    #      after it has expired.
 
     # Check if PyGithub version is < 1.56
     if hasattr(github, 'GithubRetry'):
@@ -110,7 +108,10 @@ def get_instance():
         # Pygithub 1.x
         time_now = datetime.utcnow()
 
-    if not _gh or (_token and time_now > _token.expires_at):
+    # Renew token already if expiry date is less then 30 min away.
+    refresh_time = timedelta(minutes=30)
+
+    if not _gh or (_token and time_now > (_token.expires_at - refresh_time)):
         _gh = connect()
     return _gh
 


### PR DESCRIPTION
The job manager crashes too often. An expired GH access token could be the reason for a crash with the error

```
github.GithubException.BadCredentialsException: 401 {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest"}
```
Such messages were reported in issue #142 

This PR attempts to prevent such crashes by renewing the GH access token before it has actually expired. Normally, it's valid for an hour. With this PR it will be renewed if it is valid for less than 30 minutes. Hence, there should be more time from actually checking the validity of the token and using it.


