### PR TITLE
add function that reads PR section from job metadata and use it in job manager

### DIFF
--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -42,7 +42,7 @@ from pyghee.utils import log
 from connections import github
 from tools import config, run_cmd
 from tools.args import job_manager_parse
-from tools.job_metadata import read_metadata_file
+from tools.job_metadata import read_job_metadata_from_file, read_metadata_file
 from tools.pr_comments import get_submitted_job_comment, update_comment
 
 
@@ -253,7 +253,7 @@ class EESSIBotSoftwareLayerJobManager:
 
     def read_job_pr_metadata(self, job_metadata_path):
         """
-        Read job metadata file and return the contents of the 'PR' section.
+        Determine metadata od a job
 
         Args:
             job_metadata_path (string): path to job metadata file
@@ -262,12 +262,7 @@ class EESSIBotSoftwareLayerJobManager:
             (ConfigParser): instance of ConfigParser corresponding to the 'PR'
                 section or None
         """
-        # reuse function from module tools.job_metadata to read metadata file
-        metadata = read_metadata_file(job_metadata_path, self.logfile)
-        if metadata and "PR" in metadata:
-            return metadata["PR"]
-        else:
-            return None
+        return read_job_metadata_from_file(job_metadata_path, self.logfile)
 
     def read_job_result(self, job_result_file_path):
         """

--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -251,19 +251,6 @@ class EESSIBotSoftwareLayerJobManager:
 
         return finished_jobs
 
-    def read_job_pr_metadata(self, job_metadata_path):
-        """
-        Determine metadata od a job
-
-        Args:
-            job_metadata_path (string): path to job metadata file
-
-        Returns:
-            (ConfigParser): instance of ConfigParser corresponding to the 'PR'
-                section or None
-        """
-        return read_job_metadata_from_file(job_metadata_path, self.logfile)
-
     def read_job_result(self, job_result_file_path):
         """
         Read job result file and return the contents of the 'RESULT' section.
@@ -345,7 +332,7 @@ class EESSIBotSoftwareLayerJobManager:
 
             # assuming that a bot job's working directory contains a metadata
             # file, its existence is used to check if the job belongs to the bot
-            metadata_pr = self.read_job_pr_metadata(job_metadata_path)
+            metadata_pr = read_job_metadata_from_file(job_metadata_path, self.logfile)
 
             if metadata_pr is None:
                 log(f"No metadata file found at {job_metadata_path} for job {job_id}, so skipping it",
@@ -441,7 +428,7 @@ class EESSIBotSoftwareLayerJobManager:
         job_metadata_path = os.path.join(job_dir, metadata_file)
 
         # check if metadata file exist
-        metadata_pr = self.read_job_pr_metadata(job_metadata_path)
+        metadata_pr = read_job_metadata_from_file(job_metadata_path, self.logfile)
         if metadata_pr is None:
             raise Exception("Unable to find metadata file")
 
@@ -586,7 +573,7 @@ class EESSIBotSoftwareLayerJobManager:
         # obtain id of PR comment to be updated (from file '_bot_jobID.metadata')
         metadata_file = f"_bot_job{job_id}.metadata"
         job_metadata_path = os.path.join(new_symlink, metadata_file)
-        metadata_pr = self.read_job_pr_metadata(job_metadata_path)
+        metadata_pr = read_job_metadata_from_file(job_metadata_path, self.logfile)
         if metadata_pr is None:
             raise Exception("Unable to find metadata file ... skip updating PR comment")
 

--- a/tests/test_eessi_bot_job_manager.py
+++ b/tests/test_eessi_bot_job_manager.py
@@ -11,10 +11,15 @@
 # license: GPLv2
 #
 
+import shutil
+
 from eessi_bot_job_manager import EESSIBotSoftwareLayerJobManager
 
 
 def test_determine_running_jobs():
+    # copy needed app.cfg from tests directory
+    shutil.copyfile("tests/test_app.cfg", "app.cfg")
+
     job_manager = EESSIBotSoftwareLayerJobManager()
 
     assert job_manager.determine_running_jobs({}) == []

--- a/tests/test_eessi_bot_job_manager.py
+++ b/tests/test_eessi_bot_job_manager.py
@@ -10,32 +10,8 @@
 #
 # license: GPLv2
 #
-import os
-import shutil
 
 from eessi_bot_job_manager import EESSIBotSoftwareLayerJobManager
-
-
-def test_read_job_pr_metadata(tmpdir):
-    # copy needed app.cfg from tests directory
-    shutil.copyfile("tests/test_app.cfg", "app.cfg")
-
-    # if metadata file does not exist, we should get None as return value
-    job_manager = EESSIBotSoftwareLayerJobManager()
-    path = os.path.join(tmpdir, 'test.metadata')
-    assert job_manager.read_job_pr_metadata(path) is None
-
-    with open(path, 'w') as fp:
-        fp.write('''[PR]
-        repo=test
-        pr_number=12345''')
-
-    metadata_pr = job_manager.read_job_pr_metadata(path)
-    expected = {
-        "repo": "test",
-        "pr_number": "12345",
-    }
-    assert metadata_pr == expected
 
 
 def test_determine_running_jobs():

--- a/tests/test_tools_job_metadata.py
+++ b/tests/test_tools_job_metadata.py
@@ -10,7 +10,6 @@
 #
 
 import os
-import shutil
 
 from tools.job_metadata import read_job_metadata_from_file
 

--- a/tests/test_tools_job_metadata.py
+++ b/tests/test_tools_job_metadata.py
@@ -1,0 +1,34 @@
+# Tests for 'tools/job_metadata.py' of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+
+import os
+import shutil
+
+from tools.job_metadata import read_job_metadata_from_file
+
+
+def test_read_job_metadata_from_file(tmpdir):
+    logfile = os.path.join(tmpdir, 'test_read_job_metadata_from_file.log')
+    # if metadata file does not exist, we should get None as return value
+    path = os.path.join(tmpdir, 'test.metadata')
+    assert read_job_metadata_from_file(path, logfile) is None
+
+    with open(path, 'w') as fp:
+        fp.write('''[PR]
+        repo=test
+        pr_number=12345''')
+
+    metadata_pr = read_job_metadata_from_file(path, logfile)
+    expected = {
+        "repo": "test",
+        "pr_number": "12345",
+    }
+    assert metadata_pr == expected

--- a/tools/job_metadata.py
+++ b/tools/job_metadata.py
@@ -80,3 +80,28 @@ def read_metadata_file(metadata_path, log_file=None):
     else:
         log(f"No metadata file found at {metadata_path}.", log_file)
         return None
+
+
+def read_job_metadata_from_file(filepath, log_file=None):$
+    """
+    Read job metadata from file
+
+    Args:
+        filepath (string): path to job metadata file
+        log_file (string): path to log file
+
+    Returns:
+        job_metadata (dict): dictionary containing job metadata or None
+    """
+
+    metadata = read_metadata_file(filepath, log_file=log_file)
+    if metadata:
+        # get PR section
+        if "PR" in metadata:
+            metadata_pr = metadata["PR"]
+        else:
+            metadata_pr = {}
+        return metadata_pr
+    else:
+        log(f"Metadata file '{filepath}' does not exist or could not be read")
+        return None

--- a/tools/job_metadata.py
+++ b/tools/job_metadata.py
@@ -82,7 +82,7 @@ def read_metadata_file(metadata_path, log_file=None):
         return None
 
 
-def read_job_metadata_from_file(filepath, log_file=None):$
+def read_job_metadata_from_file(filepath, log_file=None):
     """
     Read job metadata from file
 


### PR DESCRIPTION
This is a small change moving code that is used in `eessi_bot_job_manager.py` into a function defined in `tools/job_metadata.py` and then use that function in `eessi_bot_job_manager.py`.

It's a step towards syncing the codes of the NESSI and EESSI bots.