### PR TITLE
Add a comment when downloading and merging from a PR fails via `comment_download_pr()`

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -464,9 +464,9 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
                                                                                        pr, job_dir)
 
             if download_pr_exit_code != 0:
-                download_comment = (f"{download_pr_error}"
-                                    f"\nUnable to download or merge changes between source branch and the destination branch.\n"
-                                    f"\nTip: This can usually be resolved by syncing your branch and solving any merge conflics")
+                download_comment = (f"`{download_pr_error}`"
+                                    f"\nUnable to download or merge changes between the source branch and the destination branch.\n"
+                                    f"\nTip: This can usually be resolved by syncing your branch and solving any merge conflics.")
                 download_comment = pr_comments.create_comment(repo_name=base_repo_name, pr_number=pr.number, comment=download_comment)
                 if download_comment:
                     log(f"{fn}(): created PR issue comment with id {download_comment.id}")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -464,13 +464,15 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
                                                                                        pr, job_dir)
 
             if download_pr_exit_code != 0:
-                download_comment = f"Download failed with error: {download_pr_error}"
-                download_comment = pr_comments.create_comment(repo_name=base_repo_name,pr_number=pr.number,comment=download_comment)
+                download_comment = f"""Unable to download or merge changes between source branch and the destination branch. Error: \n
+                                     {download_pr_error}\n
+                                     Tip: This can usually be resolved by syncing your branch"""
+                download_comment = pr_comments.create_comment(repo_name=base_repo_name, pr_number=pr.number, comment=download_comment)
                 if download_comment:
                     log(f"{fn}(): created PR issue comment with id {download_comment.id}")
                 else:
-                    log(f"{fn}(): failed to create PR issue comment ")
-                raise RuntimeError(download_pr_error)
+                    log(f"{fn}(): failed to create PR issue comment")
+            raise RuntimeError(download_pr_error)
 
             # prepare job configuration file 'job.cfg' in directory <job_dir>/cfg
             cpu_target = '/'.join(arch.split('/')[1:])
@@ -508,7 +510,7 @@ def prepare_job_cfg(job_dir, build_env_cfg, repos_cfg, repo_id, software_subdir,
 
     jobcfg_dir = os.path.join(job_dir, 'cfg')
     # create ini file job.cfg with entries:
-    # [site_config
+    # [site_config]
     # local_tmp = LOCAL_TMP_VALUE
     # shared_fs_path = SHARED_FS_PATH
     # build_logs_dir = BUILD_LOGS_DIR

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -464,9 +464,9 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
                                                                                        pr, job_dir)
 
             if download_pr_exit_code != 0:
-                download_comment = f"""{download_pr_error}
-                                       Unable to download or merge changes between source branch and the destination branch.
-                                       Tip: This can usually be resolved by syncing your branch"""
+                download_comment = (f"{download_pr_error}"
+                                    f"\nUnable to download or merge changes between source branch and the destination branch.\n"
+                                    f"\nTip: This can usually be resolved by syncing your branch and solving any merge conflics")
                 download_comment = pr_comments.create_comment(repo_name=base_repo_name, pr_number=pr.number, comment=download_comment)
                 if download_comment:
                     log(f"{fn}(): created PR issue comment with id {download_comment.id}")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -464,9 +464,9 @@ def prepare_jobs(pr, cfg, event_info, action_filter):
                                                                                        pr, job_dir)
 
             if download_pr_exit_code != 0:
-                download_comment = f"""Unable to download or merge changes between source branch and the destination branch. Error: \n
-                                     {download_pr_error}\n
-                                     Tip: This can usually be resolved by syncing your branch"""
+                download_comment = f"""{download_pr_error}
+                                       Unable to download or merge changes between source branch and the destination branch.
+                                       Tip: This can usually be resolved by syncing your branch"""
                 download_comment = pr_comments.create_comment(repo_name=base_repo_name, pr_number=pr.number, comment=download_comment)
                 if download_comment:
                     log(f"{fn}(): created PR issue comment with id {download_comment.id}")

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -26,7 +26,7 @@ from datetime import datetime
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from tasks.build import Job, create_pr_comment
+from tasks.build import Job
 from tools import run_cmd, run_subprocess
 from tools.job_metadata import create_metadata_file, read_metadata_file
 from tools.pr_comments import PRComment, get_submitted_job_comment
@@ -475,18 +475,3 @@ def test_create_read_metadata_file(mocked_github, tmpdir):
     job_id5 = "555"
     with pytest.raises(TypeError):
         create_metadata_file(job5, job_id5, pr_comment)
-
-def test_comment_download_pr(tmpdir):
-    """Tests for function comment_download_pr."""
-
-    base_repo_name = "EESSI/software-layer"
-    pr = MockPullRequest(999)
-    download_pr_exit_code = 1
-    download_pr_error = "Cannot apply patch"
-
-    # Test exception is raised if there was an error
-    with patch('tools.pr_comments.create_comment') as mock_download_error:
-        mock_download_error = "error"
-        with pytest.raises(Exception):
-            comment_download_pr(base_repo_name, pr, download_pr_exit_code, download_pr_error)
-

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -26,7 +26,7 @@ from datetime import datetime
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from tasks.build import Job, create_pr_comment, comment_download_pr, download_pr
+from tasks.build import Job, create_pr_comment
 from tools import run_cmd, run_subprocess
 from tools.job_metadata import create_metadata_file, read_metadata_file
 from tools.pr_comments import PRComment, get_submitted_job_comment
@@ -489,50 +489,4 @@ def test_comment_download_pr(tmpdir):
         mock_download_error = "error"
         with pytest.raises(Exception):
             comment_download_pr(base_repo_name, pr, download_pr_exit_code, download_pr_error)
-
-
-def test_download_pr(tmpdir):
-    """Tests for function download_pr."""
-
-    base_repo_name = "EESSI/software-layer"
-    pr = MockPullRequest(12)
-    # Test git clone error is returned properly
-    download_pr_exit_code = 1
-    invalid_url_part = "invalid_clone_url"
-    output, error, exit_code = download_pr(repo_name = base_repo_name, 
-                                           branch_name = invalid_url_part, pr = pr, 
-                                           arch_job_dir = tmpdir)
-    assert exit_code == download_pr_exit_code
-    assert error == "error: pathspec 'invalid_clone_url' did not match any file(s) known to git\n"
-
-    # Test git checkout error is returned properly
-    shutil.copyfile("tests/1.diff", os.path.join(tmpdir, "1.diff"))
-    pr = MockPullRequest(12)
-    download_pr_exit_code = 1
-    branch_name = "develop"
-
-
-    class CustomMock(object):
-        calls = 0
-        def run_cmd(self, arg):
-            self.calls += 1
-            if self.calls != 2:
-                return None
-            else:
-                return DEFAULT
-    
-    run_cmd.side_effect = CustomMock().run_cmd
-
-
-    
-    output, error, exit_code = download_pr(repo_name = base_repo_name, 
-                                           branch_name = branch_name, pr = pr, 
-                                           arch_job_dir = tmpdir)
-
-    # assert exit_code == 1
-    # assert error == "error: pathspec 'invalid_clone_url' did not match any file(s) known to git\n"
-
-    # Test curl error is returned properly
-
-    # Test git apply error is returned properly
 

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -18,7 +18,6 @@ import os
 import re
 import shutil
 from unittest.mock import patch
-from unittest import TestCase
 
 # Third party imports (anything installed into the local Python environment)
 from collections import namedtuple
@@ -26,7 +25,7 @@ from datetime import datetime
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from tasks.build import Job
+from tasks.build import Job, create_pr_comment
 from tools import run_cmd, run_subprocess
 from tools.job_metadata import create_metadata_file, read_metadata_file
 from tools.pr_comments import PRComment, get_submitted_job_comment

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 from unittest.mock import patch
+from unittest import TestCase
 
 # Third party imports (anything installed into the local Python environment)
 from collections import namedtuple
@@ -25,7 +26,7 @@ from datetime import datetime
 import pytest
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from tasks.build import Job, create_pr_comment
+from tasks.build import Job, create_pr_comment, comment_download_pr, download_pr
 from tools import run_cmd, run_subprocess
 from tools.job_metadata import create_metadata_file, read_metadata_file
 from tools.pr_comments import PRComment, get_submitted_job_comment
@@ -474,3 +475,64 @@ def test_create_read_metadata_file(mocked_github, tmpdir):
     job_id5 = "555"
     with pytest.raises(TypeError):
         create_metadata_file(job5, job_id5, pr_comment)
+
+def test_comment_download_pr(tmpdir):
+    """Tests for function comment_download_pr."""
+
+    base_repo_name = "EESSI/software-layer"
+    pr = MockPullRequest(999)
+    download_pr_exit_code = 1
+    download_pr_error = "Cannot apply patch"
+
+    # Test exception is raised if there was an error
+    with patch('tools.pr_comments.create_comment') as mock_download_error:
+        mock_download_error = "error"
+        with pytest.raises(Exception):
+            comment_download_pr(base_repo_name, pr, download_pr_exit_code, download_pr_error)
+
+
+def test_download_pr(tmpdir):
+    """Tests for function download_pr."""
+
+    base_repo_name = "EESSI/software-layer"
+    pr = MockPullRequest(12)
+    # Test git clone error is returned properly
+    download_pr_exit_code = 1
+    invalid_url_part = "invalid_clone_url"
+    output, error, exit_code = download_pr(repo_name = base_repo_name, 
+                                           branch_name = invalid_url_part, pr = pr, 
+                                           arch_job_dir = tmpdir)
+    assert exit_code == download_pr_exit_code
+    assert error == "error: pathspec 'invalid_clone_url' did not match any file(s) known to git\n"
+
+    # Test git checkout error is returned properly
+    shutil.copyfile("tests/1.diff", os.path.join(tmpdir, "1.diff"))
+    pr = MockPullRequest(12)
+    download_pr_exit_code = 1
+    branch_name = "develop"
+
+
+    class CustomMock(object):
+        calls = 0
+        def run_cmd(self, arg):
+            self.calls += 1
+            if self.calls != 2:
+                return None
+            else:
+                return DEFAULT
+    
+    run_cmd.side_effect = CustomMock().run_cmd
+
+
+    
+    output, error, exit_code = download_pr(repo_name = base_repo_name, 
+                                           branch_name = branch_name, pr = pr, 
+                                           arch_job_dir = tmpdir)
+
+    # assert exit_code == 1
+    # assert error == "error: pathspec 'invalid_clone_url' did not match any file(s) known to git\n"
+
+    # Test curl error is returned properly
+
+    # Test git apply error is returned properly
+


### PR DESCRIPTION
Adds a new function `comment_download_pr()` that takes the exit codes from `download_pr()` to give an helpful message via a GH comment on an open PR. 

The aim is to mostly handle situations where a merge conflict due to an upstream merge prevents the `git apply` step in `download_pr()` from working. At this stage of `download_pr()`, the recent changes (a patch) are downloaded and `git apply` is used. When a merge conflict is present, `git apply` fails with an error and which not reported by the bot and made visible to the user.

For this change, I also explicitly pass the error codes out of `download_pr()` to be able to expose the error message to the user and handle the errors.

To be done in the future, add unit tests to the new functionality. I have started, but not managed to finish the mocking and testing framework for this function. Adding this PR so we have have this functionality earlier.