### PR TITLE
add function to determine comment id for a job and use it

### DIFF
--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -26,6 +26,7 @@ from connections import github
 from tasks.build import CFG_DIRNAME, JOB_CFG_FILENAME, JOB_REPO_ID, JOB_REPOSITORY
 from tasks.build import get_build_env_cfg
 from tools import config, pr_comments, run_cmd
+from tools.job_metadata import read_job_metadata_from_file
 
 
 BUCKET_NAME = "bucket_name"
@@ -72,6 +73,26 @@ def determine_job_dirs(pr_number):
     job_directories = glob.glob(glob_str)
 
     return job_directories
+
+
+def determine_pr_comment_id(job_dir):
+    """
+    Determines pr_comment_id by reading _bot_job{JOBID}.metadata in job_dir.
+
+    Args:
+        job_dir (string): working directory of the job
+
+    Returns:
+        (int): id of comment corresponding to job in pull request or -1
+    """
+    # assumes that last part of job_dir encodes the job's id
+    job_id = os.path.basename(os.path.normpath(job_dir))
+    job_metadata_file = os.path.join(job_dir, f"_bot_job{job_id}.metadata")
+    job_metadata = read_job_metadata_from_file(job_metadata_file)
+    if job_metadata and "pr_comment_id" in job_metadata:
+        return int(job_metadata["pr_comment_id"])
+    else:
+        return -1
 
 
 def determine_slurm_out(job_dir):
@@ -371,10 +392,13 @@ def determine_successful_jobs(job_dirs):
     for job_dir in job_dirs:
         slurm_out = determine_slurm_out(job_dir)
         eessi_tarballs = determine_eessi_tarballs(job_dir)
+        pr_comment_id = determine_pr_comment_id(job_dir)
+
         if check_build_status(slurm_out, eessi_tarballs):
             log(f"{funcname}(): SUCCESSFUL build in '{job_dir}'")
             successes.append({'job_dir': job_dir,
                               'slurm_out': slurm_out,
+                              'pr_comment_id': pr_comment_id,
                               'eessi_tarballs': eessi_tarballs})
         else:
             log(f"{funcname}(): FAILED build in '{job_dir}'")
@@ -448,6 +472,7 @@ def determine_tarballs_to_deploy(successes, upload_policy):
 
         if deploy:
             to_be_deployed[build_target] = {"job_dir": s["job_dir"],
+                                            "pr_comment_id": job["pr_comment_id"],
                                             "timestamp": timestamp}
 
     return to_be_deployed

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -77,7 +77,7 @@ def determine_job_dirs(pr_number):
 
 def determine_pr_comment_id(job_dir):
     """
-    Determines pr_comment_id by reading _bot_job{JOBID}.metadata in job_dir.
+    Determine pr_comment_id by reading _bot_job{JOBID}.metadata in job_dir.
 
     Args:
         job_dir (string): working directory of the job

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -427,9 +427,9 @@ def determine_tarballs_to_deploy(successes, upload_policy):
     log(f"{funcname}(): num successful jobs {len(successes)}")
 
     to_be_deployed = {}
-    for s in successes:
+    for job in successes:
         # all tarballs for successful job
-        tarballs = s["eessi_tarballs"]
+        tarballs = job["eessi_tarballs"]
         log(f"{funcname}(): num tarballs {len(tarballs)}")
 
         # full path to first tarball for successful job
@@ -462,7 +462,7 @@ def determine_tarballs_to_deploy(successes, upload_policy):
             else:
                 deploy = True
         elif upload_policy == "once":
-            uploaded = uploaded_before(build_target, s["job_dir"])
+            uploaded = uploaded_before(build_target, job["job_dir"])
             if uploaded is None:
                 deploy = True
             else:
@@ -471,7 +471,7 @@ def determine_tarballs_to_deploy(successes, upload_policy):
                     f"{indent_fname}has been uploaded through '{uploaded}'")
 
         if deploy:
-            to_be_deployed[build_target] = {"job_dir": s["job_dir"],
+            to_be_deployed[build_target] = {"job_dir": job["job_dir"],
                                             "pr_comment_id": job["pr_comment_id"],
                                             "timestamp": timestamp}
 


### PR DESCRIPTION
This is a follow up PR to sync bot codes used for EESSI and NESSI. It includes the following changes

- adds function `determine_pr_comment_id` which reads the attribute `pr_comment_id` from the job's metadata file (all current bot instances already provide that attribute when creating the job's metadata file)
- the function is then used when successful jobs are determined (in function `determine_successful_jobs`) and the comment id is added to a dictionary that contains information for each job
- another function (`determine_tarballs_to_deploy`) adds the comment id to a dictionary storing information about jobs/tarballs to deploy
- also includes slight code readability improvement by replacing a one letter variable name (`s`) with a more descriptive name (`job`)