### PR TITLE
only respond to bot commands

### DIFF
--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -31,7 +31,8 @@ import tasks.deploy as deploy
 from tasks.deploy import deploy_built_artefacts
 from tools import config
 from tools.args import event_handler_parse
-from tools.commands import EESSIBotCommand, EESSIBotCommandError, get_bot_command
+from tools.commands import EESSIBotCommand, EESSIBotCommandError,
+    contains_any_bot_command, get_bot_command
 from tools.permissions import check_command_permission
 from tools.pr_comments import create_comment
 
@@ -113,7 +114,25 @@ class EESSIBotSoftwareLayer(PyGHee):
         # currently, only commands in new comments are supported
         #  - commands have the syntax 'bot: COMMAND [ARGS*]'
 
-        # first check if sender is authorized to send any command
+        # only scan for commands in newly created comments
+        if action == 'created':
+            comment_received = request_body['comment']['body']
+            self.log(f"comment action '{action}' is handled")
+        else:
+            # NOTE we do not respond to an updated PR comment with yet another
+            #      new PR comment, because it would make the bot very noisy or
+            #      worse could result in letting the bot enter an endless loop
+            self.log(f"comment action '{action}' not handled")
+            return
+        # at this point we know that we are handling a new comment
+
+        # check if comment does not contain a bot command
+        if not contains_any_bot_command(comment_received):
+            self.log(f"comment does not contain a bot comment; not processing it further")
+            return
+        # at this point we know that the comment contains a bot command
+
+        # check if sender is authorized to send any command
         # - this serves a double purpose:
         #   1. check permission
         #   2. skip any comment updates that were done by the bot itself
@@ -149,17 +168,6 @@ class EESSIBotSoftwareLayer(PyGHee):
             return
         else:
             self.log(f"account `{sender}` has permission to send commands to bot")
-
-        # only scan for commands in newly created comments
-        if action == 'created':
-            comment_received = request_body['comment']['body']
-            self.log(f"comment action '{action}' is handled")
-        else:
-            # NOTE we do not respond to an updated PR comment with yet another
-            #      new PR comment, because it would make the bot very noisy or
-            #      worse could result in letting the bot enter an endless loop
-            self.log(f"comment action '{action}' not handled")
-            return
 
         # search for commands in comment
         comment_response = ''

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -128,7 +128,7 @@ class EESSIBotSoftwareLayer(PyGHee):
 
         # check if comment does not contain a bot command
         if not contains_any_bot_command(comment_received):
-            self.log(f"comment does not contain a bot comment; not processing it further")
+            self.log("comment does not contain a bot comment; not processing it further")
             return
         # at this point we know that the comment contains a bot command
 

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -31,7 +31,7 @@ import tasks.deploy as deploy
 from tasks.deploy import deploy_built_artefacts
 from tools import config
 from tools.args import event_handler_parse
-from tools.commands import EESSIBotCommand, EESSIBotCommandError,
+from tools.commands import EESSIBotCommand, EESSIBotCommandError, \
     contains_any_bot_command, get_bot_command
 from tools.permissions import check_command_permission
 from tools.pr_comments import create_comment

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -20,6 +20,19 @@ from pyghee.utils import log
 from tools.filter import EESSIBotActionFilter, EESSIBotActionFilterError
 
 
+def contains_any_bot_command(body):
+    """
+    Checks if argument contains any bot command.
+
+    Args:
+        body (string): possibly multi-line string that may contain a bot command
+
+    Returns:
+        (bool): True if bot command found, False otherwise
+    """
+    return any(map(get_bot_command, body.split('\n')))
+
+
 def get_bot_command(line):
     """
     Retrieve bot command from a line.


### PR DESCRIPTION
This let the bot only respond to comments which contain a bot command. If so it will either process the command if the sender is authorised to send commands to the bot or it will just respond with a note that the sender is not authorised.

The PR has been tested by letting two different accounts (one authorised, one not authorised) send comments with and without bot commands. See comment https://github.com/trz42/software-layer/pull/72#issuecomment-1965222781 and below.

The PR essentially adds a new function `contains_any_bot_command` and rearranges the processing in `handle_issue_comment_event` by first checking if the comment was newly created (only newly created comments are considered for processing bot commands), then checking if it contains any bot command, then proceeding with the processing of the commands (incl checking if the sender has permission to send a bot command).