### PR TITLE
Improve display of build targets

### DIFF
--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -338,15 +338,15 @@ class EESSIBotSoftwareLayer(PyGHee):
 
         comment = f"Instance `{app_name}` is configured to build for:"
         architectures = ['/'.join(arch.split('/')[1:]) for arch in arch_map.keys()]
-        comment += "- architectures: "
+        comment += "\n- architectures: "
         if len(architectures) > 0:
-            comment += f"{', '.join([f"`{arch}`" for arch in architectures])}"
+            comment += f"{', '.join([f'`{arch}`' for arch in architectures])}"
         else:
             comment += "none"
-        repositories = [repo_id for repo_id in repo_cfg[REPO_TARGET_MAP].keys()]
-        comment += "- repositories: "
+        repositories = list(set([repo_id for repo_ids in repo_cfg[REPO_TARGET_MAP].values() for repo_id in repo_ids]))
+        comment += "\n- repositories: "
         if len(repositories) > 0:
-            comment += f"{', '.join([f"`{repo_id}`" for repo_id in repositories])}"
+            comment += f"{', '.join([f'`{repo_id}`' for repo_id in repositories])}"
         else:
             comment += "none"
 

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -336,15 +336,19 @@ class EESSIBotSoftwareLayer(PyGHee):
         arch_map = get_architecture_targets(self.cfg)
         repo_cfg = get_repo_cfg(self.cfg)
 
-        comment = f"Instance `{app_name}` is configured to build:"
-
-        for arch in arch_map.keys():
-            # check if repo_target_map contains an entry for {arch}
-            if arch not in repo_cfg[REPO_TARGET_MAP]:
-                self.log(f"skipping arch {arch} because repo target map does not define repositories to build for")
-                continue
-            for repo_id in repo_cfg[REPO_TARGET_MAP][arch]:
-                comment += f"\n- arch `{'/'.join(arch.split('/')[1:])}` for repo `{repo_id}`"
+        comment = f"Instance `{app_name}` is configured to build for:"
+        architectures = ['/'.join(arch.split('/')[1:]) for arch in arch_map.keys()]
+        comment += "- architectures: "
+        if len(architectures) > 0:
+            comment += f"{', '.join([f"`{arch}`" for arch in architectures])}"
+        else:
+            comment += "none"
+        repositories = [repo_id for repo_id in repo_cfg[REPO_TARGET_MAP].keys()]
+        comment += "- repositories: "
+        if len(repositories) > 0:
+            comment += f"{', '.join([f"`{repo_id}`" for repo_id in repositories])}"
+        else:
+            comment += "none"
 
         self.log(f"PR opened: comment '{comment}'")
 


### PR DESCRIPTION
Shortens the list of "build targets" (architectures and repository ids). This is shown when a PR is opened or for the command `bot: show_config`. Tested in https://github.com/trz42/software-layer/pull/72

Example:

# Old display
Instance `dev-PR254` is configured to build:
- arch `x86_64/amd/zen2` for repo `nessi-2022.11-swl-deb10`
- arch `x86_64/amd/zen2` for repo `nessi-2023.06-cl`
- arch `x86_64/amd/zen2` for repo `nessi-2023.06-swl-deb10`
- arch `x86_64/amd/zen2` for repo `nessi-2023.06-swl-deb11`
- arch `aarch64/generic` for repo `nessi-2022.11-swl-deb10`
- arch `aarch64/generic` for repo `nessi-2023.06-cl`
- arch `aarch64/generic` for repo `nessi-2023.06-swl-deb10`
- arch `aarch64/generic` for repo `nessi-2023.06-swl-deb11`
- arch `aarch64/thunderx2` for repo `nessi-2022.11-swl-deb10`
- arch `aarch64/thunderx2` for repo `nessi-2023.06-cl`
- arch `aarch64/thunderx2` for repo `nessi-2023.06-swl-deb10`
- arch `aarch64/thunderx2` for repo `nessi-2023.06-swl-deb11`

# New display
Instance `dev-PR254` is configured to build for:
- architectures: `x86_64/amd/zen2`, `aarch64/generic`, `aarch64/thunderx2`
- repositories: `nessi-2023.06-cl`, `nessi-2023.06-swl-deb11`, `nessi-2023.06-swl-deb10`, `nessi-2022.11-swl-deb10`