### PR TITLE
mark `with_accelerator` setting in `[submitted_job_comments]`' section as required

### DIFF
--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -97,7 +97,8 @@ REQUIRED_CONFIG = {
         config.REPO_TARGETS_SETTING_REPOS_CFG_DIR],                # required
     config.SECTION_SUBMITTED_JOB_COMMENTS: [
         config.SUBMITTED_JOB_COMMENTS_SETTING_INITIAL_COMMENT,     # required
-        config.SUBMITTED_JOB_COMMENTS_SETTING_AWAITS_RELEASE]      # required
+        config.SUBMITTED_JOB_COMMENTS_SETTING_AWAITS_RELEASE,      # required
+        config.SUBMITTED_JOB_COMMENTS_SETTING_WITH_ACCELERATOR],   # required
     }
 
 


### PR DESCRIPTION
follow-up for #280

Without having `with_accelerator` set in `app.cfg`, the event handler crashes when processing a bot build command with:
```
[20240917-T13:47:58] WARNING: A crash occurred!
Traceback (most recent call last):
  File "/home/boegel/eessi-bot-software-layer/venv/lib64/python3.9/site-packages/pyghee/lib.py", line 170, in process_event
    self.handle_event(event_info, log_file=log_file)
  File "/home/boegel/eessi-bot-software-layer/venv/lib64/python3.9/site-packages/pyghee/lib.py", line 102, in handle_event
    handler(event_info, log_file=log_file)
  File "/home/boegel/eessi-bot-software-layer/eessi_bot_event_handler.py", line 287, in handle_issue_comment_event
    update = self.handle_bot_command(event_info, cmd)
  File "/home/boegel/eessi-bot-software-layer/eessi_bot_event_handler.py", line 469, in handle_bot_command
    return handler(event_info, bot_command)
  File "/home/boegel/eessi-bot-software-layer/eessi_bot_event_handler.py", line 515, in handle_bot_command_build
    submitted_jobs = submit_build_jobs(pr, event_info, bot_command.action_filters)
  File "/home/boegel/eessi-bot-software-layer/tasks/build.py", line 840, in submit_build_jobs
    pr_comment = create_pr_comment(job, job_id, app_name, pr, gh, symlink)
  File "/home/boegel/eessi-bot-software-layer/tasks/build.py", line 766, in create_pr_comment
    accelerator_spec = f"{submitted_job_comments_cfg[config.SUBMITTED_JOB_COMMENTS_SETTING_WITH_ACCELERATOR]}"
  File "/usr/lib64/python3.9/configparser.py", line 1257, in __getitem__
    raise KeyError(key)
KeyError: 'with_accelerator'
```

With this small enhancement, the event handler fails at startup if `with_accelerator` is not set:
```
Missing configuration item "with_accelerator" in section "submitted_job_comments" of configuration file app.cfg.
```