### PR TITLE
implement exportvariable filter

### DIFF
--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -10,6 +10,7 @@
 #
 # author: Kenneth Hoste (@boegel)
 # author: Thomas Roeblitz (@trz42)
+# author: Sam Moors (@smoors)
 #
 # license: GPLv2
 #
@@ -23,6 +24,14 @@
 #    for example, repos.cfg and configuration file bundles for repositories
 
 echo "Starting bot-build.slurm"
+EXPORT_VARS_SCRIPT=bot/export_vars.sh
+if [ -f ${EXPORT_VARS_SCRIPT} ]; then
+    echo "${EXPORT_VARS_SCRIPT} script found in '${PWD}', so sourcing it!"
+    source ${EXPORT_VARS_SCRIPT}
+else
+    echo "could not find ${EXPORT_VARS_SCRIPT} script in '${PWD}', skipping" >&2
+fi
+echo "$EXPORT_VARS_SCRIPT finished"
 BOT_BUILD_SCRIPT=bot/build.sh
 if [ -f ${BOT_BUILD_SCRIPT} ]; then
     echo "${BOT_BUILD_SCRIPT} script found in '${PWD}', so running it!"

--- a/tools/filter.py
+++ b/tools/filter.py
@@ -20,16 +20,18 @@ from pyghee.utils import log
 # (none yet)
 
 
-# NOTE because one can use any prefix of one of the four components below to
+# NOTE because one can use any prefix of one of the components below to
 # define a filter, we need to make sure that no two filters share the same
 # prefix OR we have to change the handling of filters.
 FILTER_COMPONENT_ACCEL = 'accelerator'
 FILTER_COMPONENT_ARCH = 'architecture'
+FILTER_COMPONENT_EXPORT = 'exportvariable'
 FILTER_COMPONENT_INST = 'instance'
 FILTER_COMPONENT_JOB = 'job'
 FILTER_COMPONENT_REPO = 'repository'
 FILTER_COMPONENTS = [FILTER_COMPONENT_ACCEL,
                      FILTER_COMPONENT_ARCH,
+                     FILTER_COMPONENT_EXPORT,
                      FILTER_COMPONENT_INST,
                      FILTER_COMPONENT_JOB,
                      FILTER_COMPONENT_REPO


### PR DESCRIPTION
fixes https://github.com/EESSI/eessi-bot-software-layer/issues/281

this implements the approach suggested by @boegel in the issue: if the filter is specified in a comment, file `bot/export_vars.sh` is created and sourced before running the `bot/build.sh` script 

notes:
- as is the case with other filters, spaces or colons cannot be used
- variables have to be specified one by one, which was easier to implement and avoids having to specify another delimiter, which then also cannot be used
- i used filter name `exportvariable` instead of the suggested `build_env` to avoid confusion with other uses of build_env in the code.

example usage:
```
bot: build arch:zen4 export:MYVAR1=myval1 export:MYVAR2=myval2
```