### PR TITLE
Set the local_tmp that is configured for a site as tmpdir

### DIFF
--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -44,7 +44,7 @@ while IFS= read -r line; do
         continue
     fi
 
-    # If another section starts and we haven't found local_tmp, stop searching
+    # If another section starts and we haven't found local_tmp, don't try to match
     if [[ $line =~ ^\[.*\]$ && $inside_site_config == true ]]; then
         inside_site_config=false
     fi

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -23,9 +23,6 @@
 #  - the directory may contain any additional files references in job.cfg,
 #    for example, repos.cfg and configuration file bundles for repositories
 
-# CVL EDIT 31-01-2025: set permissive umask for building
-umask 0002
-
 echo "Starting bot-build.slurm"
 EXPORT_VARS_SCRIPT=cfg/export_vars.sh
 if [ -f ${EXPORT_VARS_SCRIPT} ]; then

--- a/scripts/bot-build.slurm
+++ b/scripts/bot-build.slurm
@@ -23,6 +23,9 @@
 #  - the directory may contain any additional files references in job.cfg,
 #    for example, repos.cfg and configuration file bundles for repositories
 
+# CVL EDIT 31-01-2025: set permissive umask for building
+umask 0002
+
 echo "Starting bot-build.slurm"
 EXPORT_VARS_SCRIPT=cfg/export_vars.sh
 if [ -f ${EXPORT_VARS_SCRIPT} ]; then
@@ -32,6 +35,38 @@ if [ -f ${EXPORT_VARS_SCRIPT} ]; then
 else
     echo "could not find ${EXPORT_VARS_SCRIPT} script in '${PWD}', skipping" >&2
 fi
+
+# First, read if there is a local_tmp defined in the site_config section of cfg/job.cfg
+JOB_CFG=cfg/job.cfg
+inside_site_config=false
+local_tmp_value=""
+while IFS= read -r line; do
+    # Check if we've reached [site_config]
+    if [[ $line =~ ^\[site_config\]$ ]]; then
+        inside_site_config=true
+        continue
+    fi
+
+    # If another section starts and we haven't found local_tmp, stop searching
+    if [[ $line =~ ^\[.*\]$ && $inside_site_config == true ]]; then
+        break
+    fi
+
+    # Extract 'local_tmp' when inside [site_config]
+    if $inside_site_config && [[ $line =~ ^local_tmp\ *=\ *([^[:space:]]+) ]]; then
+        local_tmp_value="${BASH_REMATCH[1]}"
+        break
+    fi
+done < "$JOB_CFG"
+if [[ -n "${local_tmp_value}" ]]; then
+    local_tmp_value=$(envsubst <<< ${local_tmp_value})
+    # Ensure dir exists before calling mktemp
+    mkdir -p ${local_tmp_value}
+    local_tmp_value=$(mktemp -d --tmpdir=${local_tmp_value} eessi_job.XXXXXXXXXX)
+    echo "Overwriting current TMPDIR '$TMPDIR' with the value '${local_tmp_value}', as configured in cfg/job.cfg"
+    export TMPDIR="${local_tmp_value}"
+fi
+
 BOT_BUILD_SCRIPT=bot/build.sh
 if [ -f ${BOT_BUILD_SCRIPT} ]; then
     echo "${BOT_BUILD_SCRIPT} script found in '${PWD}', so running it!"


### PR DESCRIPTION
This is what I'm using for [this build](https://github.com/EESSI/software-layer/pull/903#issuecomment-2638547844), which was succesful.

It resolves the issue I had that a having a `TMPDIR` set on a system would cause `mktemp` in the `create_tarball.sh` to error out, because the `TMPDIR` wasn't available in the container. The fundamental issue is that `local_tmp` is not unique, so we don't want to bind-mount that directly into the container, as it might be shared between jobs. 

In this PR, we use the `local_tmp` that is configured and use `mktemp` to create a new directory within. That's what we will then use as the `TMPDIR`. This ensures that the `app.cfg` fully controls the `TMPDIR` used. Note that one can _still_ define `local_tmp = \$TMPDIR` if one wants to use the `TMPDIR` that would be set in a job, so there is no loss of generality here - just more control for whomever configures the bot.

We then set `STORAGE=${TMPDIR}` in the `bot/build.sh`, so that anything step (e.g. the `eessi-install-software.sh`) that uses `--storage` as argument to the `eessi_container.sh` will use this dir as a basis. Some of the steps will create subdirs within `TMPDIR`, e.g. with `mktemp`, or otherwise. That's all fine. Right now, they typically get bind-mounted as well, though strictly speaking, that'd no longer be needed since their parent dir (`$TMPDIR`) will be bind-mounted.

Note that putting this at the `bot-build.slurm` level is the only way in which we can globally override the `TMPDIR`. We could have tried to do this in each of the respective steps, but that means duplication of code, and if we ever add a step, we need to remember to do that as well. This is more robust. 