### PR TITLE
avoid that host initialisation scripts are run when launching container

### DIFF
--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -417,6 +417,8 @@ def upload_artefact(job_dir, payload, timestamp, repo_name, pr_number, pr_commen
 
         container_cmd = [container_runtime, ]
         container_cmd.extend(['exec'])
+        # avoid execution of system level initialisation scripts
+        container_cmd.extend(['--contain'])
         # avoid that $HOME 'leaks' in due to system settings
         container_cmd.extend(['--no-home'])
         for bind in bind_mounts:


### PR DESCRIPTION
Apparently launching a container may run some initialisation scripts from the host inside the container. This is likely not needed nor desired. This small PR adds the option `--contain` to when we launch a container to run the script that uploads files to an S3 bucket.