### PR TITLE
use bot name as namespace

### DIFF
--- a/.github/workflows/tests_scripts.yml
+++ b/.github/workflows/tests_scripts.yml
@@ -24,16 +24,30 @@ jobs:
           echo "Very important stuff" > out.txt
           export FILE_TO_SIGN="out.txt"
           # Sign the file
-          ./scripts/sign_verify_file_ssh.sh sign id_rsa.pem "$FILE_TO_SIGN"
+          ./scripts/sign_verify_file_ssh.sh sign id_rsa.pem "$FILE_TO_SIGN" ci
           # Create an allowed_signers file based on the public key
-          echo -n "allowed_identity " > allowed_signers
+          valid_before=$(date --date='today+3days' +%Y%m%d)
+          echo -n 'allowed_identity namespaces="ci",valid-before="'$valid_before'" ' > allowed_signers
           cat id_rsa.pem.pub >> allowed_signers
           # Verify the signature
           ./scripts/sign_verify_file_ssh.sh verify allowed_signers "$FILE_TO_SIGN"
           # Make a new signature that does not appear in the allowed signers file
           ssh-keygen -t rsa -b 4096 -m PEM -f id_rsa.alt.pem -N ""
           # Replace the allowed signers file
-          echo -n "disallowed_identity " > allowed_signers
+          echo -n 'disallowed_identity namespaces="ci",valid-before="'$valid_before'" ' > allowed_signers
           cat id_rsa.alt.pem.pub >> allowed_signers
           # Make sure signature checking fails in this case
           ./scripts/sign_verify_file_ssh.sh verify allowed_signers "$FILE_TO_SIGN" && exit 1 || echo "Expected failure for unknown identity"
+          # Check if wrong namespace let verification fail
+          # Replace the allowed signers file
+          echo -n 'wrong_namespace_identity namespaces="CI",valid-before="'$valid_before'" ' > allowed_signers
+          cat id_rsa.pem.pub >> allowed_signers
+          # Make sure signature checking fails in this case
+          ./scripts/sign_verify_file_ssh.sh verify allowed_signers "$FILE_TO_SIGN" && exit 2 || echo "Expected failure for wrong namespace"
+          # Check if expired key let verification fail
+          # Replace the allowed signers file
+          valid_expired=$(date --date='today-3days' +%Y%m%d)
+          echo -n 'expired_key_identity namespaces="ci",valid-before="'$valid_expired'" ' > allowed_signers
+          cat id_rsa.pem.pub >> allowed_signers
+          # Make sure signature checking fails in this case
+          ./scripts/sign_verify_file_ssh.sh verify allowed_signers "$FILE_TO_SIGN" && exit 3 || echo "Expected failure for expired key"

--- a/scripts/eessi-upload-to-staging
+++ b/scripts/eessi-upload-to-staging
@@ -75,6 +75,8 @@ function display_help
   echo "                                    expansion will be applied; arg '-l'"   >&2
   echo "                                    lists variables that are defined at"   >&2
   echo "                                    the time of expansion"                 >&2
+  echo "  -b | --bot-instance NAME       -  name of the bot instance that uploads" >&2
+  echo "                                    files to S3"                           >&2
   echo "  -e | --endpoint-url URL        -  endpoint url (needed for non AWS S3)"  >&2
   echo "  -h | --help                    -  display this usage information"        >&2
   echo "  -i | --pr-comment-id           -  identifier of a PR comment; may be"    >&2
@@ -134,6 +136,7 @@ sign_key=
 sign_script=
 
 # provided via options in the bot's config file app.cfg and/or command line argument
+bot_instance=
 metadata_prefix=
 artefact_prefix=
 
@@ -145,6 +148,10 @@ while [[ $# -gt 0 ]]; do
   case $1 in
     -a|--artefact-prefix)
       artefact_prefix="$2"
+      shift 2
+      ;;
+    -b|--bot-instance)
+      bot_instance="$2"
       shift 2
       ;;
     -e|--endpoint-url)
@@ -263,7 +270,7 @@ for file in "$*"; do
         # 1st sign artefact, and upload signature
         if [[ "${sign}" = "1" ]]; then
           # sign artefact
-          ${sign_script} sign ${sign_key} ${file}
+          ${sign_script} sign ${sign_key} ${file} ${bot_instance}
           # TODO check if signing worked (just check exit code == 0)
           sig_file=${file}.sig
           aws_sig_file=${aws_file}.sig
@@ -314,7 +321,7 @@ for file in "$*"; do
         # 2nd sign metadata file, and upload signature
         if [[ "${sign}" = "1" ]]; then
           # sign metadata file
-          ${sign_script} sign ${sign_key} ${metadata_file}
+          ${sign_script} sign ${sign_key} ${metadata_file} ${bot_instance}
           # TODO check if signing worked (just check exit code == 0)
           sig_metadata_file=${metadata_file}.sig
           aws_sig_metadata_file=${aws_metadata_file}.sig

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -266,6 +266,8 @@ def upload_artefact(job_dir, payload, timestamp, repo_name, pr_number, pr_commen
     metadata_prefix = deploycfg.get(config.DEPLOYCFG_SETTING_METADATA_PREFIX)
     artefact_prefix = deploycfg.get(config.DEPLOYCFG_SETTING_ARTEFACT_PREFIX)
     signing_str = deploycfg.get(config.DEPLOYCFG_SETTING_SIGNING) or ''
+    github = cfg[config.SECTION_GITHUB]
+    app_name = github.get(config.GITHUB_SETTING_APP_NAME)
     try:
         signing = json.loads(signing_str)
     except json.decoder.JSONDecodeError:
@@ -375,6 +377,7 @@ def upload_artefact(job_dir, payload, timestamp, repo_name, pr_number, pr_commen
     cmd_args.extend(['--pr-comment-id', str(pr_comment_id)])
     cmd_args.extend(['--pull-request-number', str(pr_number)])
     cmd_args.extend(['--repository', repo_name])
+    cmd_args.extend(['--bot-instance', app_name])
     cmd_args.extend(sign_args)
     cmd_args.append(abs_path)
 


### PR DESCRIPTION
Use the bot instance's name as the namespace when signing files. Both sign and verify steps are updated. The verification is also prepared to support additional options such as `valid-before`.

CI tests are adjusted and extended to cover new functionality.

Part of CI output (added tests):
```
Verifying the signature against allowed signers...
Checking principal: wrong_namespace_identity and namespace: CI
Couldn't verify signature: namespace does not match
Could not verify signature.
Error: No valid signature found.
Expected failure for wrong namespace
Verifying the signature against allowed signers...
Checking principal: expired_key_identity and namespace: ci
allowed_signers:1: key has expired: verify time 2025-03-14T21:23:43 > valid-before 2025-03-11T00:00:00
Could not verify signature.
Error: No valid signature found.
Expected failure for expired key
```