### PR TITLE
delete pre-existing signature files + small fixes

### DIFF
--- a/scripts/eessi-upload-to-staging
+++ b/scripts/eessi-upload-to-staging
@@ -222,17 +222,17 @@ set -- "${POSITIONAL_ARGS[@]}"
 
 # ensure that either none or both of $sign_key and $sign_script are defined
 if [[ -n "${sign_key}" ]] && [[ -n "${sign_script}" ]]; then
-  sign=1
+  sign=yes
 elif [[ -n "${sign_key}" ]]; then
-  sign=0
+  sign=no
   echo "Error: Signing requires a key (${sign_key}) AND a script (${sign_script}); likely the bot config is incomplete" >&2
   exit 1
 elif [[ -n "${sign_script}" ]]; then
-  sign=0
+  sign=no
   echo "Error: Signing requires a key (${sign_key}) AND a script (${sign_script}); likely the bot config is incomplete" >&2
   exit 1
 else
-  sign=0
+  sign=no
 fi
 
 # infer bucket_base:
@@ -268,11 +268,16 @@ for file in "$*"; do
         fi
         aws_file=$(basename ${file})
         # 1st sign artefact, and upload signature
-        if [[ "${sign}" = "1" ]]; then
+        if [[ "${sign}" = "yes" ]]; then
+          sig_file=${file}.sig
+          # delete sig file if it already exists
+          if [[ -f "${sig_file}" ]]; then
+            rm -f ${sig_file}
+            echo "INFO: removed existing signature file (${sig_file})"
+          fi
           # sign artefact
           ${sign_script} --sign --private-key ${sign_key} --file ${file} --namespace ${bot_instance}
           # TODO check if signing worked (just check exit code == 0)
-          sig_file=${file}.sig
           aws_sig_file=${aws_file}.sig
 
           # uploading signature
@@ -319,11 +324,16 @@ for file in "$*"; do
           aws_path=$(envsubst <<< "${metadata_prefix}")
         fi
         # 2nd sign metadata file, and upload signature
-        if [[ "${sign}" = "1" ]]; then
+        if [[ "${sign}" = "yes" ]]; then
+          sig_metadata_file=${metadata_file}.sig
+          # delete sig file if it already exists
+          if [[ -f "${sig_metadata_file}" ]]; then
+            rm -f ${sig_metadata_file}
+            echo "INFO: removed existing signature file (${sig_metadata_file})"
+          fi
           # sign metadata file
           ${sign_script} --sign --private-key ${sign_key} --file ${metadata_file} --namespace ${bot_instance}
           # TODO check if signing worked (just check exit code == 0)
-          sig_metadata_file=${metadata_file}.sig
           aws_sig_metadata_file=${aws_metadata_file}.sig
 
           echo "  store metadata signature at ${aws_path}/${aws_sig_metadata_file}"


### PR DESCRIPTION
Small PR to deal with the case that a deploy label is set again, and then the sign script would not recreate the signature if it exists from before.

Also addresses some suggestions on values for the `$sign` variable (0 $\rightarrow$ 'no' and 1 $\rightarrow$ 'yes').