### PR TITLE
change logic that checks if filter matches context in which an action shall be performed

### DIFF
--- a/tools/filter.py
+++ b/tools/filter.py
@@ -37,13 +37,13 @@ FILTER_COMPONENTS = [FILTER_COMPONENT_ACCEL,
                      FILTER_COMPONENT_REPO
                      ]
 
-COMPONENT_TOO_SHORT = "component in filter spec '{component}:{pattern}' is too short; must be 3 characters or longer"
-COMPONENT_UNKNOWN = "unknown component={component} in {component}:{pattern}"
-FILTER_EMPTY_PATTERN = "pattern in filter string '{filter_string}' is empty"
-FILTER_FORMAT_ERROR = "filter string '{filter_string}' does not conform to format 'component:pattern'"
+COMPONENT_TOO_SHORT = "component in filter spec '{component}:{value}' is too short; must be 3 characters or longer"
+COMPONENT_UNKNOWN = "unknown component={component} in {component}:{value}"
+FILTER_EMPTY_VALUE = "value in filter string '{filter_string}' is empty"
+FILTER_FORMAT_ERROR = "filter string '{filter_string}' does not conform to format 'component:value'"
 UNKNOWN_COMPONENT_CONST = "unknown component constant {component}"
 
-Filter = namedtuple('Filter', ('component', 'pattern'))
+Filter = namedtuple('Filter', ('component', 'value'))
 
 
 class EESSIBotActionFilterError(Exception):
@@ -64,7 +64,7 @@ class EESSIBotActionFilter:
     Class for representing a filter that limits in which contexts bot commands
     are applied. A filter contains a list of key:value pairs where the key
     corresponds to a component (see FILTER_COMPONENTS) and the value is a
-    pattern used to filter commands based on the context a command is applied to.
+    string used to filter commands based on the context a command is applied to.
     """
     def __init__(self, filter_string):
         """
@@ -101,15 +101,15 @@ class EESSIBotActionFilter:
         """
         self.action_filters = []
 
-    def add_filter(self, component, pattern):
+    def add_filter(self, component, value):
         """
-        Adds a filter given by a component and a pattern
+        Adds a filter given by a component and a value. Uses the full component
+        name even if only a prefix was used.
 
         Args:
             component (string): any prefix (min 3 characters long) of known filter
                 components (see FILTER_COMPONENTS)
-            pattern (string): regular expression pattern that is applied to a
-                string representing the component
+            value (string): string that represents value of component
 
         Returns:
             None (implicitly)
@@ -122,7 +122,7 @@ class EESSIBotActionFilter:
         # - it is a 3+ character-long string, _and_
         # - it is a prefix of one of the elements in FILTER_COMPONENTS
         if len(component) < 3:
-            msg = COMPONENT_TOO_SHORT.format(component=component, pattern=pattern)
+            msg = COMPONENT_TOO_SHORT.format(component=component, value=value)
             log(msg)
             raise EESSIBotActionFilterError(msg)
         full_component = None
@@ -135,17 +135,17 @@ class EESSIBotActionFilter:
                 break
         if full_component:
             log(f"processing component {component}")
-            # replace '-' with '/' in pattern when using 'architecture' filter
+            # replace '-' with '/' in value when using 'architecture' filter
             #   component (done to make sure that values are comparable)
             if full_component == FILTER_COMPONENT_ARCH:
-                pattern = pattern.replace('-', '/')
-            # replace '=' with '/' in pattern when using 'accelerator' filter
+                value = value.replace('-', '/')
+            # replace '=' with '/' in value when using 'accelerator' filter
             #   component (done to make sure that values are comparable)
             if full_component == FILTER_COMPONENT_ACCEL:
-                pattern = pattern.replace('=', '/')
-            self.action_filters.append(Filter(full_component, pattern))
+                value = value.replace('=', '/')
+            self.action_filters.append(Filter(full_component, value))
         else:
-            msg = COMPONENT_UNKNOWN.format(component=component, pattern=pattern)
+            msg = COMPONENT_UNKNOWN.format(component=component, value=value)
             log(msg)
             raise EESSIBotActionFilterError(msg)
 
@@ -154,14 +154,14 @@ class EESSIBotActionFilter:
         Adds a filter provided as a string
 
         Args:
-            filter_string (string): filter provided as component:pattern string
+            filter_string (string): filter provided as component:value string
 
         Returns:
             None (implicitly)
 
         Raises:
            EESSIBotActionFilterError: raised if filter_string does not conform
-               to 'component:pattern' format or pattern is empty
+               to 'component:value' format or value is empty
         """
         _filter_split = filter_string.split(':')
         if len(_filter_split) != 2:
@@ -169,48 +169,48 @@ class EESSIBotActionFilter:
             log(msg)
             raise EESSIBotActionFilterError(msg)
         if len(_filter_split[0]) < 3:
-            msg = COMPONENT_TOO_SHORT.format(component=_filter_split[0], pattern=_filter_split[1])
+            msg = COMPONENT_TOO_SHORT.format(component=_filter_split[0], value=_filter_split[1])
             log(msg)
             raise EESSIBotActionFilterError(msg)
         if len(_filter_split[1]) == 0:
-            msg = FILTER_EMPTY_PATTERN.format(filter_string=filter_string)
+            msg = FILTER_EMPTY_VALUE.format(filter_string=filter_string)
             log(msg)
             raise EESSIBotActionFilterError(msg)
         self.add_filter(_filter_split[0], _filter_split[1])
 
     def get_filter_by_component(self, component):
         """
-        Returns filter pattern for component.
+        Returns filter value for component.
 
         Args:
             component (string): one of FILTER_COMPONENTS
 
         Returns:
-            (list): list of pattern for filters whose component matches argument
+            (list): list of value for filters whose component matches argument
         """
         if component not in FILTER_COMPONENTS:
             msg = UNKNOWN_COMPONENT_CONST.format(component=component)
             raise EESSIBotActionFilterError(msg)
 
-        pattern = []
+        values = []
         for _filter in self.action_filters:
             if component == _filter.component:
-                pattern.append(_filter.pattern)
-        return pattern
+                values.append(_filter.value)
+        return values
 
-    def remove_filter(self, component, pattern):
+    def remove_filter(self, component, value):
         """
-        Removes all elements matching the filter given by (component, pattern)
+        Removes all elements matching the filter given by (component, value)
 
         Args:
             component (string): one of FILTER_COMPONENTS
-            pattern (string): regex that is applied to a string representing the component
+            value (string): value for the component
 
         Returns:
             None (implicitly)
         """
         if len(component) < 3:
-            msg = COMPONENT_TOO_SHORT.format(component=component, pattern=pattern)
+            msg = COMPONENT_TOO_SHORT.format(component=component, value=value)
             log(msg)
             raise EESSIBotActionFilterError(msg)
         full_component = None
@@ -223,7 +223,7 @@ class EESSIBotActionFilter:
                 break
         if not full_component:
             # the component provided as argument is not in the list of FILTER_COMPONENTS
-            msg = COMPONENT_UNKNOWN.format(component=component, pattern=pattern)
+            msg = COMPONENT_UNKNOWN.format(component=component, value=value)
             log(msg)
             raise EESSIBotActionFilterError(msg)
 
@@ -238,8 +238,8 @@ class EESSIBotActionFilter:
             #      3-character-long prefix (e.g., 'repository' and 'repeat' would
             #      have the same prefix 'rep')
             _filter = self.action_filters[index]
-            if _filter.component.startswith(component) and pattern == _filter.pattern:
-                log(f"removing filter ({_filter.component}, {pattern})")
+            if _filter.component.startswith(component) and value == _filter.value:
+                log(f"removing filter ({_filter.component}, {value})")
                 self.action_filters.pop(index)
 
     def to_string(self):
@@ -255,52 +255,55 @@ class EESSIBotActionFilter:
         filter_str_list = []
         for _filter in self.action_filters:
             cm = _filter.component
-            re = _filter.pattern
+            re = _filter.value
             filter_str_list.append(f"{cm}:{re}")
         return " ".join(filter_str_list)
 
     def check_filters(self, context):
         """
-        Checks filters for a given context which is defined by one to five
-        components (accelerator, architecture, instance, job, repository)
+        Checks if a filter matches a given context which is defined by three
+        components (architecture, instance, repository)
+        A single component of a filter matches the corresponding component in a
+        context if the values for these components are exactly the same.
 
         Args:
-            context (dict) : dictionary that maps components to their value
+            context (dict) : dictionary that contents (component,value)-pairs
+                representing the context in which the method is called
 
         Returns:
-            True if no filters are defined or all defined filters match
-                their corresponding component in the given context
-            False if any defined filter does not match its corresponding
-                component in the given context
+            True if all defined components in a given context match their
+                corresponding component in a filter
+            False otherwise
         """
-        # if no filters are defined we return True
-        if len(self.action_filters) == 0:
-            return True
-
-        # we have at least one filter which has to match or we return False
+        # default result is False
         check = False
 
         # examples:
         #   filter: 'arch:intel instance:AWS' --> evaluates to True if
-        #       context['architecture'] matches 'intel' and if
-        #       context['instance'] matches 'AWS'
+        #     context['architecture'] is 'intel' and if context['instance'] is 'AWS'
         #   filter: 'repository:eessi-2023.06' --> evaluates to True if
-        #       context['repository'] matches 'eessi-2023.06'
+        #     context['repository'] is 'eessi-2023.06'
 
-        # we iterate over all defined filters
-        for af in self.action_filters:
-            if af.component in context:
-                value = context[af.component]
-                # replace - with / in architecture component
-                if af.component == FILTER_COMPONENT_ARCH:
-                    value = value.replace('-', '/')
-                # replace = with / in accelerator component
-                if af.component == FILTER_COMPONENT_ACCEL:
-                    value = value.replace('=', '/')
-                if re.search(af.pattern, value):
-                    # if the pattern of the filter matches
-                    check = True
-                else:
-                    check = False
-                    break
-        return check
+        # we iterate over the three components 'architecture', 'instance' and
+        #   'repository' and verify if their value in the given context matches
+        #   the corresponding value in the filter
+        context_components = [ FILTER_COMPONENT_ARCH, FILTER_COMPONENT_INST, FILTER_COMPONENT_REPO ]
+        for component in context_components:
+            filter_values = self.get_filter_by_component(component)
+            if len(filter_values) == 0:
+                # no filter for component provided --> at least one filter per
+                #   component MUST be given
+                return False
+            if component in context:
+                # check if all values for the filter are identical to the value
+                #   of the component in the context
+                context_value = context[component]
+                if component == FILTER_COMPONENT_ARCH:
+                    context_value = context_value.replace('-', '/')
+                for filter_value in filter_values:
+                    if filter_value != context_value:
+                        return False
+            else:
+                # missing component in context, could lead to unexpected behavior
+                return False
+        return True


### PR DESCRIPTION
Draft PR because
- [ ] functionality should be tested
- [ ] unit tests may be adjusted to the new logic

This PR changes the logic that checks if an action filter, for example, defined by `arch:x86_64/generic inst:eessi-bot-mc-aws repo:eessi.io-2023.06-software` in a command such as
```
bot: build arch:x86_64/generic inst:eessi-bot-mc-aws repo:eessi.io-2023.06-software
```
matches the context in which the action (`build` in this example) shall be performed.

The changes shall avoid accidentally triggered actions. These changes have become more and more important with the growing number of bot instances and the growing number of potential build targets. Without these changes a simple command such as
```
bot: build
```
where no filter is provided would lead to submitting build jobs for all configured build targets on all running bot instances (unless a bot instance would employ other restrictions such as only accepting commands from specific GitHub users).

The PR implements the following changes:
- all three components `architecture`, `instance` and `repository` have to be provided for a filter,
- the context against which a filter is checked also must have all three components defined (this should always be the case due to the implementation, but it is also checked)
- the values of the three components in a filter have to be identical to the values of the corresponding component in the context (before a substring provided by a filter could match the value of the component in the context, e.g., `architecture:zen` would match `zen2`, `zen3` and `zen4` values for the architecture component in a context)

Since the checks are now based on exact string matches, the PR renamed the use of 'pattern' to 'value'.