### PR TITLE
make space before bot command optional

### DIFF
--- a/tools/commands.py
+++ b/tools/commands.py
@@ -50,10 +50,10 @@ def get_bot_command(line):
     match = regex.search(line)
     if match:
         cmd = match.group(1).rstrip()
-        log(f"Bot command found in '{line}': {cmd}")
+        log(f"{fn}(): Bot command found in '{line}': {cmd}")
         return cmd
     else:
-        log(f"No bot command found using pattern '{regex.pattern}' in: {line}")
+        log(f"{fn}(): No bot command found using pattern '{regex.pattern}' in: {line}")
         return None
 
 


### PR DESCRIPTION
`bot:build ...` or `bot: build` should both work just fine, no reason to require a hard space in between