### PR TITLE
Make sure to print an informative message to the log when a `for:` argument is missing

### DIFF
--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -530,6 +530,12 @@ class EESSIBotSoftwareLayer(PyGHee):
         pr_number = event_info['raw_request_body']['issue']['number']
         pr = gh.get_repo(repo_name).get_pull(pr_number)
         build_msg = ''
+        # Require that build_params is defined, it is required. Otherwise, return early
+        if bot_command.build_params is None:
+            build_msg = "No 'for:' argument was passed to the bot:build command. This argumen is required, so "
+            build_msg += "not submitting build jobs"
+            return build_msg
+
         if check_build_permission(pr, event_info):
             # use filter from command
             submitted_jobs = submit_build_jobs(pr, event_info, bot_command.action_filters, bot_command.build_params)

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -532,7 +532,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         build_msg = ''
         # Require that build_params is defined, it is required. Otherwise, return early
         if bot_command.build_params is None:
-            build_msg = "No 'for:' argument was passed to the bot:build command. This argumen is required, so "
+            build_msg = "No 'for:' argument was passed to the bot:build command. This argument is required, so "
             build_msg += "not submitting build jobs"
             return build_msg
 

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -87,6 +87,7 @@ class EESSIBotCommand:
         # TODO add function name to log messages
         cmd_as_list = cmd_str.split()
         self.command = cmd_as_list[0]  # E.g. 'build' or 'help'
+        self.build_params = None
 
         # TODO always init self.action_filters with empty EESSIBotActionFilter?
         if len(cmd_as_list) > 1:


### PR DESCRIPTION
Set a default `self.build_params = None` on constructiong the `EESSIBotCommand`. Then, in handling the bot build command, don't submit a job if `self.build_params` wasn't defined

fixes #330