### PR TITLE
Make sure that builds for different repos don't get deduplicated by the last_build option

### DIFF
--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -591,6 +591,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         repo_name = event_info['raw_request_body']['repository']['full_name']
         pr_number = event_info['raw_request_body']['issue']['number']
         status_table = request_bot_build_issue_comments(repo_name, pr_number)
+        self.log(f"Retrieved status table from issue comments: {status_table}")
 
         if 'last_build' in bot_command.general_args:
             # If the bot command is something like 'bot:status =last_build', then only retain the last build for each
@@ -625,7 +626,17 @@ class EESSIBotSoftwareLayer(PyGHee):
                 'on arch': [], 'for arch': [], 'for repo': [], 'date': [], 'status': [], 'url': [], 'result': []
             }
             for x in range(0, len(sorted_table['date'])):
-                if sorted_table['for arch'][x] not in status_table_last['for arch']:
+                # Check if the current 'for arch' AND repo are already in the status_table_last. If not, add it
+                already_present=False
+                for y in range(0, len(status_table_last['for arch']):
+                    if (
+                        sorted_table['for arch'][x] == status_table_last['for arch'][y]
+                        and sorted_table['for repo'][x] == status_table_last['for repo'][y]
+                    ):
+                        already_present=True
+                        # One match is enough, we don't append in this case, no need to look further
+                        break
+                if not already_present:
                     self.log(f"arch: {sorted_table['for arch'][x]} not yet in status_table_last")
                     for key in status_table_last:
                         self.log(f"Adding to '{key}' and the value {sorted_table[key][x]}")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -628,7 +628,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             for x in range(0, len(sorted_table['date'])):
                 # Check if the current 'for arch' AND repo are already in the status_table_last. If not, add it
                 already_present = False
-                for y in range(0, len(status_table_last['for arch']):
+                for y in range(0, len(status_table_last['for arch'])):
                     if (
                         sorted_table['for arch'][x] == status_table_last['for arch'][y]
                         and sorted_table['for repo'][x] == status_table_last['for repo'][y]

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -626,7 +626,7 @@ class EESSIBotSoftwareLayer(PyGHee):
                 'on arch': [], 'for arch': [], 'for repo': [], 'date': [], 'status': [], 'url': [], 'result': []
             }
             for x in range(0, len(sorted_table['date'])):
-                # Check if the current 'for arch' AND repo are already in the status_table_last. If not, add it
+                # Check if the current 'for arch' AND 'for repo' are already in the status_table_last. If not, add it
                 already_present = False
                 for y in range(0, len(status_table_last['for arch'])):
                     if (

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -627,13 +627,13 @@ class EESSIBotSoftwareLayer(PyGHee):
             }
             for x in range(0, len(sorted_table['date'])):
                 # Check if the current 'for arch' AND repo are already in the status_table_last. If not, add it
-                already_present=False
+                already_present = False
                 for y in range(0, len(status_table_last['for arch']):
                     if (
                         sorted_table['for arch'][x] == status_table_last['for arch'][y]
                         and sorted_table['for repo'][x] == status_table_last['for repo'][y]
                     ):
-                        already_present=True
+                        already_present = True
                         # One match is enough, we don't append in this case, no need to look further
                         break
                 if not already_present:


### PR DESCRIPTION
Fixes https://github.com/EESSI/eessi-bot-software-layer/issues/344

Note that I also added a `self.log`, to log the status table before we start modifying for the `last_build` option. Reason is that I was unable to reproduce https://github.com/EESSI/eessi-bot-software-layer/issues/343 so the only chance we have at resolving that _if_ it happens again is to have some better logging in place and see if we spot anything strange.