### PR TITLE
fix dependency versions for npm and Docker

### DIFF
--- a/.github/workflows/build_smee_client_container_image.yaml
+++ b/.github/workflows/build_smee_client_container_image.yaml
@@ -55,8 +55,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }} # don't publish if this is part of an open PR
           file: containers/Dockerfile.smee-client
-          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
-          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+          no-cache: true
+          # cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          # cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
 
       - name: Move cache
         run: |

--- a/.github/workflows/build_smee_client_container_image.yaml
+++ b/.github/workflows/build_smee_client_container_image.yaml
@@ -55,9 +55,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }} # don't publish if this is part of an open PR
           file: containers/Dockerfile.smee-client
-          no-cache: true
-          # cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
-          # cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
 
       - name: Move cache
         run: |

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install markdownlint-cli
         run: npm install -g igorshubovych/markdownlint-cli#192ad822316c3a22fb3d3cc8aa6eafa0b8488360 # v0.45.0
-        #SHA from https://github.com/igorshubovych/markdownlint-cli/commit/192ad822316c3a22fb3d3cc8aa6eafa0b8488360
+        # SHA from https://github.com/igorshubovych/markdownlint-cli/commit/192ad822316c3a22fb3d3cc8aa6eafa0b8488360
 
       - name: Run markdownlint
         run: markdownlint "**/*.md" --ignore .git 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -10,7 +10,7 @@
 #
 
 name: Markdown Lint
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 # Declare default permissions as read only.
 permissions: read-all
 
@@ -27,7 +27,8 @@ jobs:
           node-version: '18'
 
       - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
+        run: npm install -g igorshubovych/markdownlint-cli#192ad822316c3a22fb3d3cc8aa6eafa0b8488360 # v0.45.0
+        #SHA from https://github.com/igorshubovych/markdownlint-cli/commit/192ad822316c3a22fb3d3cc8aa6eafa0b8488360
 
       - name: Run markdownlint
         run: markdownlint "**/*.md" --ignore .git 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.0
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install markdownlint-cli
         run: npm install -g igorshubovych/markdownlint-cli#192ad822316c3a22fb3d3cc8aa6eafa0b8488360 # v0.45.0

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -3,6 +3,10 @@ ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
 # pinning base image to specific hash (corresponding to lts-alpine)
 FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787
 ARG smee_client_version_commit
+# Remove any existing installation first
+RUN rm -rf /usr/local/lib/node_modules/smee-client /usr/local/lib/node_modules/.smee-client-*
+
+# Then install
 RUN npm install --global "probot/smee-client#${smee_client_version_commit}"
 ENTRYPOINT ["smee"]
 CMD ["--help"]

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -1,12 +1,14 @@
+ARG smee_client_version=4.4.1
 ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
 
 # pinning base image to specific hash (corresponding to lts-alpine)
 FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787
+ARG smee_client_version
 ARG smee_client_version_commit
 # Remove any existing installation first
-RUN rm -rf /usr/local/lib/node_modules/smee-client /usr/local/lib/node_modules/.smee-client-*
+# RUN rm -rf /usr/local/lib/node_modules/smee-client /usr/local/lib/node_modules/.smee-client-*
 
 # Then install
-RUN npm install --global "probot/smee-client#${smee_client_version_commit}"
+RUN npm install --global probot/smee-client@${smee_client_version}
 ENTRYPOINT ["smee"]
 CMD ["--help"]

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -1,4 +1,4 @@
-ARG smee_client_version=4.4.1
+ARG smee_client_version=4.2.1
 ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
 
 # pinning base image to specific hash (corresponding to lts-alpine)

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -1,6 +1,7 @@
 ARG smee_client_version=4.2.1
 
-FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787 # lts-alpine
+# pinning base image to specific hash (corresponding to lts-alpine)
+FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787
 ARG smee_client_version
 RUN npm install --global smee-client@${smee_client_version}
 ENTRYPOINT ["smee"]

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -1,8 +1,8 @@
-ARG smee_client_version=4.2.1
+ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
 
 # pinning base image to specific hash (corresponding to lts-alpine)
 FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787
-ARG smee_client_version
-RUN npm install --global smee-client@${smee_client_version}
+ARG smee_client_version_commit
+RUN npm install --global probot/smee-client#${smee_client_version_commit}
 ENTRYPOINT ["smee"]
 CMD ["--help"]

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -9,6 +9,6 @@ ARG smee_client_version_commit
 # RUN rm -rf /usr/local/lib/node_modules/smee-client /usr/local/lib/node_modules/.smee-client-*
 
 # Then install
-RUN npm install --global probot/smee-client@${smee_client_version}
+RUN npm install --global smee-client@${smee_client_version}
 ENTRYPOINT ["smee"]
 CMD ["--help"]

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -3,6 +3,6 @@ ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
 # pinning base image to specific hash (corresponding to lts-alpine)
 FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787
 ARG smee_client_version_commit
-RUN npm install --global probot/smee-client#${smee_client_version_commit}
+RUN npm install --global "probot/smee-client#${smee_client_version_commit}"
 ENTRYPOINT ["smee"]
 CMD ["--help"]

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -1,12 +1,10 @@
 ARG smee_client_version=4.4.1
-ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
+# ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
 
 # pinning base image to specific hash (corresponding to lts-alpine)
 FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787
 ARG smee_client_version
-ARG smee_client_version_commit
-# Remove any existing installation first
-# RUN rm -rf /usr/local/lib/node_modules/smee-client /usr/local/lib/node_modules/.smee-client-*
+# ARG smee_client_version_commit
 
 # Then install
 RUN npm install --global smee-client@${smee_client_version}

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -1,6 +1,6 @@
 ARG smee_client_version=4.2.1
 
-FROM node:lts-alpine
+FROM node@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787 # lts-alpine
 ARG smee_client_version
 RUN npm install --global smee-client@${smee_client_version}
 ENTRYPOINT ["smee"]

--- a/containers/Dockerfile.smee-client
+++ b/containers/Dockerfile.smee-client
@@ -1,4 +1,4 @@
-ARG smee_client_version=4.2.1
+ARG smee_client_version=4.4.1
 ARG smee_client_version_commit=b837fa85fd05853731160e21356ffd30c8c3e791 # v4.4.1
 
 # pinning base image to specific hash (corresponding to lts-alpine)


### PR DESCRIPTION
fixes two issues in #342. Pinning of npm install when building the smee-client container did not work out as hoped for.