### PR TITLE
release notes for v0.11.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,28 @@
 This file contains a description of the major changes to the EESSI
 build-and-deploy bot. For more detailed information, please see the git log.
 
+v0.11.0 (28 January 2026)
+--------------------------
+
+This is a minor release of the EESSI build-and-deploy bot.
+
+Bug fixes:
+* consider all builds for `bot: status [last_build]` command (#357)
+  * this also replaces running `curl` by using the `requests` library for one `curl` call
+
+Improvements:
+* adds support for new command `bot: cancel jobid:[JOBID] ...` (#359)
+  * only the owner of a job can cancel it
+  * multiple jobs can be cancelled by specifying multiple `jobid:[JOBID]`
+    arguments separated by space
+
+Changes to 'app.cfg' settings (see README.md and app.cfg.example for details):
+* CHANGED (required) 'no_build_permission_comment' in section '[buildenv]'
+  Note! sites using the old value may see misleading comments added by the bot,
+  but the bot will work without the change.
+* NEW (required) 'cancel_command' in section '[buildenv]'
+
+
 v0.10.0 (13 November 2025)
 --------------------------
 


### PR DESCRIPTION
v0.11.0 (28 January 2026)
--------------------------

This is a minor release of the EESSI build-and-deploy bot.

Bug fixes:
* consider all builds for `bot: status [last_build]` command (#357)
  * this also replaces running `curl` by using the `requests` library for one `curl` call

Improvements:
* adds support for new command `bot: cancel jobid:[JOBID] ...` (#359)
  * only the owner of a job can cancel it
  * multiple jobs can be cancelled by specifying multiple `jobid:[JOBID]`
    arguments separated by space

Changes to 'app.cfg' settings (see README.md and app.cfg.example for details):
* CHANGED (required) 'no_build_permission_comment' in section '[buildenv]'
  Note! sites using the old value may see misleading comments added by the bot,
  but the bot will work without the change.
* NEW (required) 'cancel_command' in section '[buildenv]'