### PR TITLE
[gitlab] Add GitLab connection and EventInfo classes

### DIFF
--- a/app.cfg.example
+++ b/app.cfg.example
@@ -17,6 +17,10 @@
 
 # Also see documentation at https://github.com/EESSI/eessi-bot-software-layer/blob/main/README.md#step5.5
 
+[git]
+# Name of the Git hosting platform (supported values are 'github' and 'gitlab')
+hosting_platform = github
+
 [github]
 # API timeout, time limit for requests to GitHub's REST API
 api_timeout = 10
@@ -42,6 +46,20 @@ installation_id = 12345678
 
 # path to the private key that was generated when the GitHub App was registered
 private_key = PATH_TO_PRIVATE_KEY
+
+[gitlab]
+# NOTE: Access token required for GitLab:
+# https://docs.gitlab.com/user/project/settings/project_access_tokens/#bot-users-for-projects
+# Must be stored in environment variable 'GITLAB_PROJECT_ACCESS_TOKEN'.
+
+# API timeout, time limit for requests to GitLab's REST API
+api_timeout = 10
+
+# Name used to refer to your bot instance - see comment for github.app_name config
+bot_name = MY-bot
+
+# The base URL of your GitLab instance
+instance_url = https://gitlab.com
 
 
 [bot_control]

--- a/connections/gitlab.py
+++ b/connections/gitlab.py
@@ -1,0 +1,87 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Sondre Bergsvaag Risanger (@sondrebr)
+#
+# license: GPLv2
+#
+
+# Standard library imports
+import os
+
+# Third party imports (anything installed into the local Python environment)
+import gitlab
+
+# Local application imports (anything from EESSI/eessi-bot-software-layer)
+from tools import config, logging
+
+
+_gl = None
+
+
+def verify_connection(gl):
+    """
+    Verifies connection to GitLab. Exits if verification fails.
+
+    Args:
+        Instance of Gitlab
+
+    Returns:
+        None (implicit)
+    """
+    try:
+        # auth tests the instance's credentials by retrieving the access token user
+        gl.auth()
+        if type(gl.user) is not gl._objects.CurrentUser:
+            raise Exception("'user' attribute of Gitlab instance is not of type 'CurrentUser'.")
+    except Exception as err:
+        logging.error(f"Failed to verify GitLab connection: {err}")
+
+
+def connect():
+    """
+    Creates a Gitlab instance, then verifies the connection.
+
+    Args:
+        No arguments
+
+    Returns:
+        None (implicit)
+    """
+    global _gl
+    cfg = config.read_config()
+    gitlab_cfg = cfg[config.SECTION_GITLAB]
+    timeout = int(gitlab_cfg.get(config.GITLAB_SETTING_API_TIMEOUT, 10))
+    url = gitlab_cfg.get(config.GITLAB_SETTING_INSTANCE_URL)
+
+    access_token = os.getenv('GITLAB_PROJECT_ACCESS_TOKEN')
+    if access_token is None:
+        logging.error("GitLab token is not available via $GITLAB_PROJECT_ACCESS_TOKEN!")
+    else:
+        del os.environ['GITLAB_PROJECT_ACCESS_TOKEN']
+
+    _gl = gitlab.Gitlab(url, access_token)
+    _gl.timeout = timeout
+    _gl.retry_transient_errors = True
+    verify_connection(_gl)
+
+
+def get_instance():
+    """
+    Returns a Gitlab instance. Creates an instance if one does not exist,
+    otherwise verifies the existing instance.
+
+    Args:
+        No arguments
+
+    Returns:
+        Instance of Gitlab
+    """
+    if not _gl:
+        connect()
+    else:
+        verify_connection(_gl)
+    return _gl

--- a/connections/gitlab.py
+++ b/connections/gitlab.py
@@ -27,7 +27,7 @@ def verify_connection(gl):
     Verifies connection to GitLab. Exits if verification fails.
 
     Args:
-        Instance of Gitlab
+        Instance of gitlab.Gitlab (from python-gitlab)
 
     Returns:
         None (implicit)
@@ -36,14 +36,14 @@ def verify_connection(gl):
         # auth tests the instance's credentials by retrieving the access token user
         gl.auth()
         if type(gl.user) is not gl._objects.CurrentUser:
-            raise Exception("'user' attribute of Gitlab instance is not of type 'CurrentUser'.")
+            raise Exception("'user' attribute of Gitlab class instance is not of type 'CurrentUser'.")
     except Exception as err:
         logging.error(f"Failed to verify GitLab connection: {err}")
 
 
 def connect():
     """
-    Creates a Gitlab instance, then verifies the connection.
+    Creates a gitlab.Gitlab instance (from python-gitlab), then verifies the connection to GitLab.
 
     Args:
         No arguments
@@ -71,14 +71,14 @@ def connect():
 
 def get_instance():
     """
-    Returns a Gitlab instance. Creates an instance if one does not exist,
+    Returns a gitlab.Gitlab instance. Creates an instance if one does not exist,
     otherwise verifies the existing instance.
 
     Args:
         No arguments
 
     Returns:
-        Instance of Gitlab
+        Instance of gitlab.Gitlab (from python-gitlab)
     """
     if not _gl:
         connect()

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -38,7 +38,7 @@ from tools.args import event_handler_parse
 from tools.commands import EESSIBotCommand, EESSIBotCommandError, \
     contains_any_bot_command, get_bot_command
 from tools.event_info import create_event_info_instance
-from tools.git import connect_to_host, get_hosting_platform
+from tools.git import connect_to_git_hosting_platform, get_git_hosting_platform
 from tools.permissions import check_command_permission
 from tools.pr_comments import ChatLevels, create_comment
 
@@ -141,7 +141,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         EESSIBotSoftwareLayer constructor. Calls constructor of PyGHee and
         initializes some configuration settings.
         """
-        event_source = get_hosting_platform()
+        event_source = get_git_hosting_platform()
         super(EESSIBotSoftwareLayer, self).__init__(event_source, *args, **kwargs)
 
         self.cfg = config.read_config()
@@ -858,8 +858,8 @@ def main():
         print("Configuration check: FAILED")
         sys.exit(1)
 
-    # Connect to Git hosting platform
-    connect_to_host()
+    # Verify that the event handler is able to connect to the Git hosting platform
+    connect_to_git_hosting_platform()
 
     if opts.file:
         app = create_app(klass=EESSIBotSoftwareLayer)

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -37,6 +37,7 @@ from tools import config
 from tools.args import event_handler_parse
 from tools.commands import EESSIBotCommand, EESSIBotCommandError, \
     contains_any_bot_command, get_bot_command
+from tools.event_info import create_event_info_instance
 from tools.git import connect_to_host, get_hosting_platform
 from tools.permissions import check_command_permission
 from tools.pr_comments import ChatLevels, create_comment
@@ -164,6 +165,21 @@ class EESSIBotSoftwareLayer(PyGHee):
             msg = msg % args
         msg = "[%s]: %s" % (funcname, msg)
         log(msg, log_file=self.logfile)
+
+    def handle_event(self, event_info, log_file=None):
+        """
+        Create EventInfo instance using event_info,
+        then pass that to PyGHee's handle_event method.
+
+        Args:
+            event_info (dict): event received by event_handler
+            log_file (string): path to log messages to
+
+        Returns:
+            None (implicit)
+        """
+        event_info_object = create_event_info_instance(event_info)
+        super().handle_event(event_info_object, log_file)
 
     def handle_issue_comment_event(self, event_info, log_file=None):
         """

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -37,6 +37,7 @@ from tools import config
 from tools.args import event_handler_parse
 from tools.commands import EESSIBotCommand, EESSIBotCommandError, \
     contains_any_bot_command, get_bot_command
+from tools.git import connect_to_host, get_hosting_platform
 from tools.permissions import check_command_permission
 from tools.pr_comments import ChatLevels, create_comment
 
@@ -95,12 +96,18 @@ REQUIRED_CONFIG = {
         config.DOWNLOAD_PR_COMMENTS_SETTING_PR_DIFF_TIP],          # required
     config.SECTION_EVENT_HANDLER: [
         config.EVENT_HANDLER_SETTING_LOG_PATH],                    # required
+    config.SECTION_GIT: [
+        config.GIT_SETTING_HOSTING_PLATFORM],                      # required
     config.SECTION_GITHUB: [
-        config.GITHUB_SETTING_API_TIMEOUT,                         # required
-        config.GITHUB_SETTING_APP_ID,                              # required
-        config.GITHUB_SETTING_APP_NAME,                            # required
-        config.GITHUB_SETTING_INSTALLATION_ID,                     # required
-        config.GITHUB_SETTING_PRIVATE_KEY],                        # required
+        config.GITHUB_SETTING_API_TIMEOUT,                         # required for github
+        config.GITHUB_SETTING_APP_ID,                              # required for github
+        config.GITHUB_SETTING_APP_NAME,                            # required for github
+        config.GITHUB_SETTING_INSTALLATION_ID,                     # required for github
+        config.GITHUB_SETTING_PRIVATE_KEY],                        # required for github
+    config.SECTION_GITLAB: [
+        config.GITLAB_SETTING_API_TIMEOUT,                         # required for gitlab
+        config.GITLAB_SETTING_BOT_NAME,                            # required for gitlab
+        config.GITLAB_SETTING_INSTANCE_URL],                       # required for gitlab
     # the poll interval setting is required for the alternative job handover
     # protocol (delayed_begin)
     config.SECTION_JOB_MANAGER: [
@@ -133,7 +140,8 @@ class EESSIBotSoftwareLayer(PyGHee):
         EESSIBotSoftwareLayer constructor. Calls constructor of PyGHee and
         initializes some configuration settings.
         """
-        super(EESSIBotSoftwareLayer, self).__init__(*args, **kwargs)
+        event_source = get_hosting_platform()
+        super(EESSIBotSoftwareLayer, self).__init__(event_source, *args, **kwargs)
 
         self.cfg = config.read_config()
         event_handler_cfg = self.cfg[config.SECTION_EVENT_HANDLER]
@@ -833,7 +841,9 @@ def main():
     else:
         print("Configuration check: FAILED")
         sys.exit(1)
-    github.connect()
+
+    # Connect to Git hosting platform
+    connect_to_host()
 
     if opts.file:
         app = create_app(klass=EESSIBotSoftwareLayer)

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -168,6 +168,7 @@ class EESSIBotSoftwareLayer(PyGHee):
 
     def handle_event(self, event_info, log_file=None):
         """
+        Override of PyGHee's handle_event method.
         Create EventInfo instance using event_info,
         then pass that to PyGHee's handle_event method.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ PyGithub
 python-gitlab
 Waitress>=3.0.1 # required to fix vulnerabilities detected by scorecards
 cryptography>=44.0.1 # required to fix vulnerabilities detected by scorecards
-PyGHee @ git+https://github.com/boegel/PyGHee.git@bd4ab122206c446bd4fe554e1344d26a64b232d3 # Pin commit adding GL support
+PyGHee @ git+https://github.com/boegel/PyGHee.git@c5e10632a45db5ca94f5cbf87ac7a90a2064e8fd # Pin commit with GL support
 retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,13 @@
 # author: Bob Droege (@bedroge)
 # author: Kenneth Hoste (@boegel)
 # author: Thomas Roeblitz (@trz42)
+# author: Sondre Bergsvaag Risanger (@sondrebr)
 #
 # license: GPLv2
 #
 PyGithub
+python-gitlab
 Waitress>=3.0.1 # required to fix vulnerabilities detected by scorecards
 cryptography>=44.0.1 # required to fix vulnerabilities detected by scorecards
-PyGHee>=0.0.3
+PyGHee @ git+https://github.com/boegel/PyGHee.git@bd4ab122206c446bd4fe554e1344d26a64b232d3 # Pin commit adding GL support
 retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@
 # license: GPLv2
 #
 PyGithub
-python-gitlab
+python-gitlab==6.5.0;python_version=="3.9" # Last version with Python 3.9 support
+python-gitlab==8.3.0;python_version>="3.10" # Most recent version on 2026-05-04
 Waitress>=3.0.1 # required to fix vulnerabilities detected by scorecards
 cryptography>=44.0.1 # required to fix vulnerabilities detected by scorecards
 PyGHee @ git+https://github.com/boegel/PyGHee.git@c5e10632a45db5ca94f5cbf87ac7a90a2064e8fd # Pin commit with GL support

--- a/tools/config.py
+++ b/tools/config.py
@@ -220,6 +220,7 @@ def check_cfg_settings(req_settings, path="app.cfg"):
     # iterate over keys in req_settings which correspond to sections ([name])
     # in the configuration file (.ini format)
     for section in req_settings.keys():
+        # Skip checking the GitLab section if the bot is configured for GitHub and vice versa
         if git_host and (section in SUPPORTED_GIT_HOSTS) and (section != git_host):
             continue
         if section not in cfg:

--- a/tools/config.py
+++ b/tools/config.py
@@ -23,6 +23,7 @@ import sys
 # (none yet)
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
+from .git import get_hosting_platform, SUPPORTED_HOSTS
 from .logging import error
 
 # define configuration constants
@@ -95,12 +96,20 @@ SECTION_FINISHED_JOB_COMMENTS = 'finished_job_comments'
 FINISHED_JOB_COMMENTS_SETTING_JOB_RESULT_UNKNOWN_FMT = 'job_result_unknown_fmt'
 FINISHED_JOB_COMMENTS_SETTING_JOB_TEST_UNKNOWN_FMT = 'job_test_unknown_fmt'
 
+SECTION_GIT = 'git'
+GIT_SETTING_HOSTING_PLATFORM = 'hosting_platform'
+
 SECTION_GITHUB = 'github'
 GITHUB_SETTING_API_TIMEOUT = 'api_timeout'
 GITHUB_SETTING_APP_ID = 'app_id'
 GITHUB_SETTING_APP_NAME = 'app_name'
 GITHUB_SETTING_INSTALLATION_ID = 'installation_id'
 GITHUB_SETTING_PRIVATE_KEY = 'private_key'
+
+SECTION_GITLAB = 'gitlab'
+GITLAB_SETTING_API_TIMEOUT = 'api_timeout'
+GITLAB_SETTING_BOT_NAME = 'bot_name'
+GITLAB_SETTING_INSTANCE_URL = 'instance_url'
 
 SECTION_JOB_MANAGER = 'job_manager'
 JOB_MANAGER_SETTING_LOG_PATH = 'log_path'
@@ -207,9 +216,12 @@ def check_cfg_settings(req_settings, path="app.cfg"):
     """
     # TODO argument path is not being used
     cfg = read_config()
+    git_host = get_hosting_platform()
     # iterate over keys in req_settings which correspond to sections ([name])
     # in the configuration file (.ini format)
     for section in req_settings.keys():
+        if git_host and (section in SUPPORTED_HOSTS) and (section != git_host):
+            continue
         if section not in cfg:
             error(f'Missing section "{section}" in configuration file {path}.')
         # iterate over list elements required for the current section

--- a/tools/config.py
+++ b/tools/config.py
@@ -216,7 +216,7 @@ def check_cfg_settings(req_settings, path="app.cfg"):
     """
     # TODO argument path is not being used
     cfg = read_config()
-    git_host = get_hosting_platform()
+    git_host = get_hosting_platform(cfg)
     # iterate over keys in req_settings which correspond to sections ([name])
     # in the configuration file (.ini format)
     for section in req_settings.keys():

--- a/tools/config.py
+++ b/tools/config.py
@@ -23,7 +23,7 @@ import sys
 # (none yet)
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from .git import get_hosting_platform, SUPPORTED_HOSTS
+from .git import get_git_hosting_platform, SUPPORTED_GIT_HOSTS
 from .logging import error
 
 # define configuration constants
@@ -216,11 +216,11 @@ def check_cfg_settings(req_settings, path="app.cfg"):
     """
     # TODO argument path is not being used
     cfg = read_config()
-    git_host = get_hosting_platform(cfg)
+    git_host = get_git_hosting_platform(cfg)
     # iterate over keys in req_settings which correspond to sections ([name])
     # in the configuration file (.ini format)
     for section in req_settings.keys():
-        if git_host and (section in SUPPORTED_HOSTS) and (section != git_host):
+        if git_host and (section in SUPPORTED_GIT_HOSTS) and (section != git_host):
             continue
         if section not in cfg:
             error(f'Missing section "{section}" in configuration file {path}.')

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -61,11 +61,11 @@ class BaseEventInfo():
         raise NotImplementedError()
 
     @cached_property
-    def comment_updated_by(self):
+    def event_id(self):
         raise NotImplementedError()
 
     @cached_property
-    def event_id(self):
+    def event_triggered_by(self):
         raise NotImplementedError()
 
     @cached_property
@@ -126,12 +126,12 @@ class GitHubEventInfo(BaseEventInfo):
         return self._request_body["comment"]["user"]["login"]
 
     @cached_property
-    def comment_updated_by(self):
-        return self._request_body["sender"]["login"]
-
-    @cached_property
     def event_id(self):
         return self.event_info["id"]
+
+    @cached_property
+    def event_triggered_by(self):
+        return self._request_body["sender"]["login"]
 
     @cached_property
     def event_type(self):
@@ -230,12 +230,12 @@ class GitLabEventInfo(BaseEventInfo):
         return created_by
 
     @cached_property
-    def comment_updated_by(self):
-        return self._request_body["user"]["username"]
-
-    @cached_property
     def event_id(self):
         return self.event_info["id"]
+
+    @cached_property
+    def event_triggered_by(self):
+        return self._request_body["user"]["username"]
 
     # Map (relevant) GitLab events to GitHub events
     _EVENT_TYPE_MAP = {

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -219,7 +219,9 @@ class GitLabEventInfo(BaseEventInfo):
     def comment_created_by(self):
         created_by_id = self._object_attributes["author_id"]
         triggered_by_id = self._request_body["user"]["id"]
-        # GL events only include the username of the user who triggered the event
+        # GL events only include the username of the user who triggered the event.
+        # E.g., if a comment was updated by someone other than the original author,
+        # we need to retrieve the name of the author from the server.
         if triggered_by_id == created_by_id:
             created_by = self._request_body["user"]["username"]
         else:
@@ -257,6 +259,9 @@ class GitLabEventInfo(BaseEventInfo):
         # Set manually and call handle_pull_request_labeled_event once per label?
         raise NotImplementedError()
 
+    # GL uses the 'object_attributes' field to store data about the event object.
+    # For example, MR events store information about the MR in 'object_attributes', while
+    # events from comments on MRs store information about the MR in the 'merge_request' field.
     @cached_property
     def pr_number(self):
         if self.event_type == "pull_request":

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -73,6 +73,14 @@ class BaseEventInfo():
         raise NotImplementedError()
 
     @cached_property
+    def issue_number(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def issue_url(self):
+        raise NotImplementedError()
+
+    @cached_property
     def label_name(self):
         raise NotImplementedError()
 
@@ -130,16 +138,20 @@ class GitHubEventInfo(BaseEventInfo):
         return self.event_info["type"]
 
     @cached_property
+    def issue_number(self):
+        return self._request_body["issue"]["number"]
+
+    @cached_property
+    def issue_url(self):
+        return self._request_body["issue"]["html_url"]
+
+    @cached_property
     def label_name(self):
         return self._request_body["label"]["name"]
 
     @cached_property
     def pr_number(self):
-        if self.event_type == "pull_request":
-            pr_num = self._request_body["pull_request"]["number"]
-        else:
-            pr_num = self._request_body["issue"]["number"]
-        return pr_num
+        return self._request_body["pull_request"]["number"]
 
     @cached_property
     def pr_merged_status(self):
@@ -147,11 +159,7 @@ class GitHubEventInfo(BaseEventInfo):
 
     @cached_property
     def pr_url(self):
-        if self.event_type == "pull_request":
-            url = self._request_body["pull_request"]["html_url"]
-        else:
-            url = self._request_body["issue"]["html_url"]
-        return url
+        return self._request_body["pull_request"]["html_url"]
 
     @cached_property
     def repo_name(self):
@@ -239,6 +247,32 @@ class GitLabEventInfo(BaseEventInfo):
     def event_type(self):
         gl_event_type = self.event_info["type"]
         return self._EVENT_TYPE_MAP.get(gl_event_type, self._UNKNOWN)
+
+    # The bot does not handle issue events, but comment events can come from both issue and MR comments.
+    # We therefore need to check what type of comment it is to get the issue numbers and URLs.
+    @cached_property
+    def issue_number(self):
+        notable_type = self._object_attributes["notable_type"]
+        if notable_type == "MergeRequest":
+            issue_iid = self._request_body["merge_request"]["iid"]
+        elif notable_type == "Issue":
+            issue_iid = self._request_body["issue"]["iid"]
+        else:
+            # Comments may also come from commits etc. - default to -1
+            issue_iid = -1
+        return issue_iid
+
+    @cached_property
+    def issue_url(self):
+        notable_type = self._object_attributes["notable_type"]
+        if notable_type == "MergeRequest":
+            issue_url = self._request_body["merge_request"]["url"]
+        elif notable_type == "Issue":
+            issue_url = self._request_body["issue"]["url"]
+        else:
+            # Comments may also come from commits etc. - default to empty string
+            issue_url = ""
+        return issue_url
 
     @cached_property
     def label_name(self):

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -1,0 +1,298 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Sondre Bergsvaag Risanger (@sondrebr)
+#
+# license: GPLv2
+#
+
+# Standard library imports
+from functools import cached_property
+
+# Third party imports (anything installed into the local Python environment)
+# (none)
+
+# Local application imports (anything from EESSI/eessi-bot-software-layer)
+from connections import gitlab
+from tools.git import get_hosting_platform, GITHUB, GITLAB
+
+
+class BaseEventInfo():
+    """
+    Base class to use for handling event info, which works differently
+    for GitHub vs. GitLab. Subscripting is implemented for compatibility.
+    If a new field needs to be accessed, add a new property to
+    retrieve it instead of subscripting/using the event_info dict.
+    """
+    def __init__(self, event_info):
+        if self.__class__ is BaseEventInfo:
+            err_msg = "Do not use this base class directly. "
+            err_msg += "Please use one of its subclasses instead."
+            raise NotImplementedError(err_msg)
+        self.event_info = event_info
+
+    # Do not override - implements subscripting for compatibility
+    def __getitem__(self, key):
+        return self.event_info[key]
+
+    @cached_property
+    def action(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def comment_id(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def comment_body(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def comment_created_by(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def comment_updated_by(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def discussion_id(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def event_id(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def event_type(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def label_name(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def pr_number(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def pr_merged_status(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def pr_url(self):
+        raise NotImplementedError()
+
+    @cached_property
+    def repo_name(self):
+        raise NotImplementedError()
+
+
+class GitHubEventInfo(BaseEventInfo):
+    """
+    EventInfo class for use with GitHub webhooks.
+    """
+    def __init__(self, event_info):
+        super().__init__(event_info)
+        self._request_body = event_info["raw_request_body"]
+
+    @cached_property
+    def action(self):
+        return self.event_info["action"]
+
+    @cached_property
+    def comment_id(self):
+        return self._request_body["comment"]["id"]
+
+    @cached_property
+    def comment_body(self):
+        return self._request_body["comment"]["body"]
+
+    @cached_property
+    def comment_created_by(self):
+        return self._request_body["comment"]["user"]["login"]
+
+    @cached_property
+    def comment_updated_by(self):
+        return self._request_body["sender"]["login"]
+
+    @cached_property
+    def discussion_id(self):
+        # Not applicable for GitHub
+        return None
+
+    @cached_property
+    def event_id(self):
+        return self.event_info["id"]
+
+    @cached_property
+    def event_type(self):
+        return self.event_info["type"]
+
+    @cached_property
+    def label_name(self):
+        return self._request_body["label"]["name"]
+
+    @cached_property
+    def pr_number(self):
+        if self.event_type == "pull_request":
+            pr_num = self._request_body["pull_request"]["number"]
+        else:
+            pr_num = self._request_body["issue"]["number"]
+        return pr_num
+
+    @cached_property
+    def pr_merged_status(self):
+        return self._request_body["pull_request"]["merged"]
+
+    @cached_property
+    def pr_url(self):
+        if self.event_type == "pull_request":
+            url = self._request_body["pull_request"]["html_url"]
+        else:
+            url = self._request_body["issue"]["html_url"]
+        return url
+
+    @cached_property
+    def repo_name(self):
+        return self._request_body["repository"]["full_name"]
+
+
+class GitLabEventInfo(BaseEventInfo):
+    """
+    EventInfo class for use with GitLab webhooks. Converts GL terminology to
+    GH equivalents where needed, e.g. event type 'note' becomes 'issue_comment'.
+    """
+    def __init__(self, event_info):
+        super().__init__(event_info)
+        self._request_body = event_info["raw_request_body"]
+        self._object_attributes = self._request_body.get("object_attributes", {})
+
+    # Map GitLab actions to GitHub actions
+    _ACTION_MAP = {
+        # Note -> comment actions
+        "create": "created",
+        "update": "edited",
+        "delete": "deleted",
+
+        # MR -> PR actions
+        # MR 'update' handled separately
+        "open": "opened",
+        "merge": "closed",
+        "close": "closed",
+    }
+    _UNKNOWN = "UNKNOWN"
+
+    @cached_property
+    def action(self):
+        gl_action = self._object_attributes["action"]
+        # GL uses a single 'update' action for MRs
+        # Need to check changes to find exact action, e.g. 'labeled'
+        if self.event_type == "pull_request" and gl_action == "update":
+            changes = self._request_body["changes"]
+            if "labels" in changes:
+                action = "labeled"
+            else:
+                action = self._UNKNOWN
+        else:
+            action = self._ACTION_MAP.get(gl_action, self._UNKNOWN)
+        return action
+
+    @cached_property
+    def comment_id(self):
+        return self._object_attributes["id"]
+
+    @cached_property
+    def comment_body(self):
+        return self._object_attributes["note"]
+
+    @cached_property
+    def comment_created_by(self):
+        created_by_id = self._object_attributes["author_id"]
+        triggered_by_id = self._request_body["user"]["id"]
+        # GL events only include the username of the user who triggered the event
+        if triggered_by_id == created_by_id:
+            created_by = self._request_body["user"]["username"]
+        else:
+            gl = gitlab.get_instance()
+            user = gl.users.get(created_by_id)
+            created_by = user.username
+        return created_by
+
+    @cached_property
+    def comment_updated_by(self):
+        return self._request_body["user"]["username"]
+
+    @cached_property
+    def discussion_id(self):
+        return self._object_attributes["discussion_id"]
+
+    @cached_property
+    def event_id(self):
+        return self.event_info["id"]
+
+    # Map (relevant) GitLab events to GitHub events
+    _EVENT_TYPE_MAP = {
+        "note": "issue_comment",
+        "merge_request": "pull_request",
+    }
+
+    @cached_property
+    def event_type(self):
+        gl_event_type = self.event_info["type"]
+        return self._EVENT_TYPE_MAP.get(gl_event_type, self._UNKNOWN)
+
+    @cached_property
+    def label_name(self):
+        # GH sends one event per label while GL sends one event with all label changes
+        # Set manually and call handle_pull_request_labeled_event once per label?
+        raise NotImplementedError()
+
+    @cached_property
+    def pr_number(self):
+        if self.event_type == "pull_request":
+            pr_iid = self._object_attributes["iid"]
+        else:
+            pr_iid = self._request_body["merge_request"]["iid"]
+        return pr_iid
+
+    @cached_property
+    def pr_merged_status(self):
+        if self.event_type == "pull_request":
+            state = self._object_attributes["state"]
+        else:
+            state = self._request_body["merge_request"]["state"]
+        return state == "merged"
+
+    @cached_property
+    def pr_url(self):
+        if self.event_type == "pull_request":
+            url = self._object_attributes["url"]
+        else:
+            url = self._request_body["merge_request"]["url"]
+        return url
+
+    @cached_property
+    def repo_name(self):
+        return self._request_body["project"]["path_with_namespace"]
+
+
+def create_event_info_instance(event_info):
+    """
+    Creates an EventInfo instance for the configured Git hosting platform.
+
+    Args:
+        event_info (dict): The event info dictionary created by PyGHee
+
+    Returns:
+        Instance of BaseEventInfo subclass
+    """
+    git_host = get_hosting_platform()
+    if git_host == GITHUB:
+        new_event_info = GitHubEventInfo(event_info)
+    elif git_host == GITLAB:
+        new_event_info = GitLabEventInfo(event_info)
+    return new_event_info

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -34,6 +34,12 @@ class BaseEventInfo():
             raise NotImplementedError(err_msg)
         self.event_info = event_info
 
+    # Prevents subclasses from overriding __getitem__
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if "__getitem__" in cls.__dict__:
+            raise Exception(f"{cls.__name__} must not override __getitem__")
+
     # Do not override - implements subscripting for compatibility
     def __getitem__(self, key):
         return self.event_info[key]

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -65,10 +65,6 @@ class BaseEventInfo():
         raise NotImplementedError()
 
     @cached_property
-    def discussion_id(self):
-        raise NotImplementedError()
-
-    @cached_property
     def event_id(self):
         raise NotImplementedError()
 
@@ -124,11 +120,6 @@ class GitHubEventInfo(BaseEventInfo):
     @cached_property
     def comment_updated_by(self):
         return self._request_body["sender"]["login"]
-
-    @cached_property
-    def discussion_id(self):
-        # Not applicable for GitHub
-        return None
 
     @cached_property
     def event_id(self):
@@ -233,10 +224,6 @@ class GitLabEventInfo(BaseEventInfo):
     @cached_property
     def comment_updated_by(self):
         return self._request_body["user"]["username"]
-
-    @cached_property
-    def discussion_id(self):
-        return self._object_attributes["discussion_id"]
 
     @cached_property
     def event_id(self):

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -17,7 +17,7 @@ from functools import cached_property
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
 from connections import gitlab
-from tools.git import get_hosting_platform, GITHUB, GITLAB
+from tools.git import get_git_hosting_platform, GITHUB, GITLAB
 
 
 class BaseEventInfo():
@@ -296,7 +296,7 @@ def create_event_info_instance(event_info):
     Returns:
         Instance of BaseEventInfo subclass
     """
-    git_host = get_hosting_platform()
+    git_host = get_git_hosting_platform()
     if git_host == GITHUB:
         new_event_info = GitHubEventInfo(event_info)
     elif git_host == GITLAB:

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -330,7 +330,7 @@ def create_event_info_instance(event_info):
     """
     git_host = get_git_hosting_platform()
     if git_host == GITHUB:
-        new_event_info = GitHubEventInfo(event_info)
+        return GitHubEventInfo(event_info)
     elif git_host == GITLAB:
-        new_event_info = GitLabEventInfo(event_info)
-    return new_event_info
+        return GitLabEventInfo(event_info)
+    return None

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -242,9 +242,15 @@ class GitLabEventInfo(BaseEventInfo):
 
     @cached_property
     def label_name(self):
-        # GH sends one event per label while GL sends one event with all label changes
-        # Set manually and call handle_pull_request_labeled_event once per label?
-        raise NotImplementedError()
+        # GL sends a single event containing all previous and current labels.
+        # Since we currently only use one label, 'bot:deploy', we can check just for that.
+        label_changes = self._request_body["changes"]["labels"]
+        # The difference between the sets will yield all newly added labels
+        added_labels = set(label_changes["current"]) - set(label_changes["previous"])
+        if "bot:deploy" in added_labels:
+            return "bot:deploy"
+        else:
+            return None
 
     # GL uses the 'object_attributes' field to store data about the event object.
     # For example, MR events store information about the MR in 'object_attributes', while

--- a/tools/git.py
+++ b/tools/git.py
@@ -49,3 +49,13 @@ def get_hosting_platform():
         if _git_host not in SUPPORTED_HOSTS:
             logging.error(f"Invalid Git host configured: '{_git_host}'")
     return _git_host
+
+
+def connect_to_host():
+    git_host = get_hosting_platform()
+    if git_host == GITHUB:
+        github.connect()
+    elif git_host == GITLAB:
+        gitlab.connect()
+    else:
+        logging.error(f"Git host not supported: '{git_host}'")

--- a/tools/git.py
+++ b/tools/git.py
@@ -31,20 +31,22 @@ SUPPORTED_HOSTS = {
 _git_host = None
 
 
-def get_hosting_platform():
+def get_hosting_platform(cfg=None):
     """
     Read the config and get the Git hosting platform the bot is configured for.
     Exit if the setting is invalid or not set.
 
     Args:
-        No arguments
+        cfg (ConfigParser): Instance of ConfigParser containing the configuration.
+            May be passed by caller to avoid re-reading the configuration file.
 
     Returns:
         (str): The configured Git hosting platform
     """
     global _git_host
     if not _git_host:
-        cfg = config.read_config()
+        if not cfg:
+            cfg = config.read_config()
         _git_host = cfg.get(config.SECTION_GIT, config.GIT_SETTING_HOSTING_PLATFORM, fallback=None)
         if _git_host not in SUPPORTED_HOSTS:
             logging.error(f"Invalid Git host configured: '{_git_host}'")

--- a/tools/git.py
+++ b/tools/git.py
@@ -23,7 +23,7 @@ from tools import config, logging
 GITHUB = "github"
 GITLAB = "gitlab"
 
-SUPPORTED_HOSTS = {
+SUPPORTED_GIT_HOSTS = {
     GITHUB,
     GITLAB,
 }
@@ -31,7 +31,7 @@ SUPPORTED_HOSTS = {
 _git_host = None
 
 
-def get_hosting_platform(cfg=None):
+def get_git_hosting_platform(cfg=None):
     """
     Read the config and get the Git hosting platform the bot is configured for.
     Exit if the setting is invalid or not set.
@@ -48,12 +48,12 @@ def get_hosting_platform(cfg=None):
         if not cfg:
             cfg = config.read_config()
         _git_host = cfg.get(config.SECTION_GIT, config.GIT_SETTING_HOSTING_PLATFORM, fallback=None)
-        if _git_host not in SUPPORTED_HOSTS:
+        if _git_host not in SUPPORTED_GIT_HOSTS:
             logging.error(f"Invalid Git host configured: '{_git_host}'")
     return _git_host
 
 
-def connect_to_host():
+def connect_to_git_hosting_platform():
     """
     Establish connection to Git hosting platform. Exit if the configured hosting
     platform is not supported by the bot.
@@ -64,7 +64,7 @@ def connect_to_host():
     Returns:
         None (implicit)
     """
-    git_host = get_hosting_platform()
+    git_host = get_git_hosting_platform()
     if git_host == GITHUB:
         github.connect()
     elif git_host == GITLAB:

--- a/tools/git.py
+++ b/tools/git.py
@@ -1,0 +1,51 @@
+# This file is part of the EESSI build-and-deploy bot,
+# see https://github.com/EESSI/eessi-bot-software-layer
+#
+# The bot helps with requests to add software installations to the
+# EESSI software layer, see https://github.com/EESSI/software-layer
+#
+# author: Sondre Bergsvaag Risanger (@sondrebr)
+#
+# license: GPLv2
+#
+
+# Standard library imports
+# (none)
+
+# Third party imports (anything installed into the local Python environment)
+# (none)
+
+# Local application imports (anything from EESSI/eessi-bot-software-layer)
+from connections import github, gitlab
+from tools import config, logging
+
+
+GITHUB = "github"
+GITLAB = "gitlab"
+
+SUPPORTED_HOSTS = {
+    GITHUB,
+    GITLAB,
+}
+
+_git_host = None
+
+
+def get_hosting_platform():
+    """
+    Read the config and get the Git hosting platform the bot is configured for.
+    Exit if the setting is invalid or not set.
+
+    Args:
+        No arguments
+
+    Returns:
+        (str): The configured Git hosting platform
+    """
+    global _git_host
+    if not _git_host:
+        cfg = config.read_config()
+        _git_host = cfg.get(config.SECTION_GIT, config.GIT_SETTING_HOSTING_PLATFORM, fallback=None)
+        if _git_host not in SUPPORTED_HOSTS:
+            logging.error(f"Invalid Git host configured: '{_git_host}'")
+    return _git_host

--- a/tools/git.py
+++ b/tools/git.py
@@ -54,6 +54,16 @@ def get_hosting_platform(cfg=None):
 
 
 def connect_to_host():
+    """
+    Establish connection to Git hosting platform. Exit if the configured hosting
+    platform is not supported by the bot.
+
+    Args:
+        No arguments
+
+    Returns:
+        None (implicit)
+    """
     git_host = get_hosting_platform()
     if git_host == GITHUB:
         github.connect()


### PR DESCRIPTION
First step towards implementing GitLab support for the bot. This PR adds:
- New/updated dependencies (`python-gitlab`, [`PyGHee` with GitLab support](https://github.com/boegel/PyGHee/pull/9))
- New config sections `git` and `gitlab`
- `connections/gitlab.py` for connecting to GitLab
- `tools/git.py` with functions:
  - `get_hosting_platform()` gets the configured Git hosting platform (GitHub/GitLab)
  - `connect_to_host()` performs initial connection to GitHub/GitLab
- `tools/event_info.py` with:
  - `BaseEventInfo` class intended as an "interface" to implement for each Git hosting platform
  - `GitHubEventInfo` class implementing `BaseEventInfo` for GitHub
  - `GitLabEventInfo` class implementing `BaseEventInfo` for GitLab
  - `create_event_info_instance()` creating an instance of the correct EventInfo class
- A `handle_event()` override in the event handler to use the new EventInfo classes

The PR does not any methods for handling GitLab events, but the events will be logged, e.g.:
```
[20260421-T10:53:03] Event received (id: 39c64e78-fdd1-4799-a9c6-568d9b7ffb4b, type: note, action: create), event data logged at [...]
[20260421-T10:53:03] Request verified: signature OK!
[20260421-T10:53:03] WARNING: [event id 39c64e78-fdd1-4799-a9c6-568d9b7ffb4b] No handler found for event type 'note' (action: create) - event was received but left unhandled!
```

`get_hosting_platform()` is intended to be used whenever platform-specific logic is required, to simplify adding support for other platforms in the future (e.g. Forgejo/Codeberg, Gitea, ...).

The `*EventInfo` classes were implemented to handle the differences between the GitHub and GitLab webhooks, such that the necessary information can be retrieved through class properties. For example, `event_info.action` returns the event action. If `GitLabEventInfo` is used, the `action` property converts the action to its GH equivalent before returning, e.g. `update` becomes `edited`.
The classes currently have support for (as far as I can tell) all `event_info` fields used by the bot.
They also have a `__getitem__()` override to support subscripting for compatibility with the existing uses of `event_info` - this version of the bot should therefore still have full GitHub support.

# Usage
Because webhooks signatures are not yet supported by GitLab (though they are [in development](https://gitlab.com/gitlab-org/gitlab/-/work_items/19367)), it is necessary to run a custom Smee server to sign the webhooks. I have a fork [here](https://github.com/sondrebr/smee.io) which should sign the events in the same way as they will be signed on GitLab in the future. I have also added a "Quickstart" section on top of the README in the fork with instructions on how to run the server.

To "use" the bot in its current state on GitLab, you need to do the following:
- Install the requirements (`pip install -r requirements.txt`)
Ensure the correct version of PyGHee (commit `c5e1063...`) is installed.
- Create a webhook on a GitLab project (`Settings` -> `Webhooks` -> `Add new`)
The webhook should have the `Comments` and `Merge request events` triggers, and must be configured with a secret token. The secret token can be generated e.g. by running `python -c "import secrets; print(secrets.token_hex())"`, and must be stored as the environment variable `GITLAB_WEBHOOK_SECRET_TOKEN`. The webhooks must also be set up to send events to the custom Smee server.
- Create a project access token for the same GitLab project (`Settings` -> `Access tokens` -> `Add new token`)
In the future, the `api` scope and `Planner` will be required for the bot to be able to write comments. For this PR, however, it just needs to be able to connect to GitLab, so the `read_api` scope and `Guest` role should be sufficient. The access token must be stored as the environment variable `GITLAB_PROJECT_ACCESS_TOKEN`.
- Configure the `git` and `gitlab` sections in `app.cfg`
In the `git` section, `hosting_platform = gitlab` must be set (if it is set to `github` instead, the bot should function normally).
In the `gitlab` section, the `api_timeout`, `bot_name`, and `instance_url` options must be set. For the `instance_url` option, you must enter the base URL of your GitLab instance, which is used along with the access token to connect to GitLab.