### PR TITLE
make parsing for scontrol command more robust for SubmitLine=

### DIFF
--- a/eessi_bot_job_manager.py
+++ b/eessi_bot_job_manager.py
@@ -281,7 +281,11 @@ class EESSIBotSoftwareLayerJobManager:
         """
         job_info = {}
         stripped_output = output.strip()
-        for pair in stripped_output.split():
+
+        # make spit of output from scontrol command more robust
+        parts = re.split(r' (?=\S+=)', stripped_output)
+
+        for pair in parts:
             key, value = pair.split('=', 1)
             job_info[key] = value
 


### PR DESCRIPTION
On one of our systems the output of the scrontrol command includes `SubmitLine=`. This is spacesperated so it gets split up. Which causes problems when splitting `pair` as paraments like `--hold` cannot be spit. This is the output of scontrol on our system:
```
JobId=13591760 JobName=prod UserId=vsc48506(2548506) GroupId=vsc48506(2548506) MCS_label=N/A Priority=0 Nice=0 Account=2025_600 QOS=dodrio-2025_600 JobState=PENDING Reason=JobHeldUser Dependency=(null) Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0 RunTime=00:00:00 TimeLimit=1-00:00:00 TimeMin=N/A SubmitTime=2026-05-05T16:31:21 EligibleTime=Unknown AccrueTime=Unknown StartTime=Unknown EndTime=Unknown Deadline=N/A SuspendTime=None SecsPreSuspend=0 LastSchedEval=2026-05-05T16:31:21 Scheduler=Main Partition=gpu_rome_a100_rhel9 AllocNode:Sid=apps51:278618 ReqNodeList=(null) ExcNodeList=(null) NodeList= NumNodes=1-1 NumCPUs=12 NumTasks=12 CPUs/Task=1 ReqB:S:C:T=0:0:*:* ReqTRES=cpu=12,mem=60960M,node=1,billing=12,gres/gpu=1 AllocTRES=(null) Socks/Node=* NtasksPerN:B:S:C=12:0:*:* CoreSpec=* MinCPUsNode=12 MinMemoryCPU=5080M MinTmpDiskNode=0 Features=(null) DelayBoot=00:00:00 OverSubscribe=OK Contiguous=0 Licenses=(null) LicensesAlloc=(null) Network=(null) Command=/dodrio/scratch/projects/2025_600/vsc48506/EESSI_bot/eessi-bot-software-layer/scripts/bot-build.slurm SubmitLine=/usr/bin/sbatch --cluster=dodrio --hold --export=NONE --nodes=1 --time=24:0:0 --mail-type=BEGIN,END,FAIL,TIME_LIMIT --hold -p gpu_rome_a100_rhel9 --ntasks-per-node=12 --gpus-per-node=1 -A 2025_600 --job-name=prod /dodrio/scratch/projects/2025_600/vsc48506/EESSI_bot/eessi-bot-software-layer/scripts/bot-build.slurm WorkDir=/dodrio/scratch/projects/2025_600/SHARED/jobs/2026.05/pr_1461/event_125b69e0-488f-11f1-8eb7-60fa5e34a41f/run_000/x86_64/amd/zen2/nvidia/cc80/eessi.io-2025.06-software Comment=stdout=/dodrio/scratch/projects/2025_600/SHARED/jobs/2026.05/pr_1461/event_125b69e0-488f-11f1-8eb7-60fa5e34a41f/run_000/x86_64/amd/zen2/nvidia/cc80/eessi.io-2025.06-software/slurm-13591760.out StdErr= StdIn=/dev/null StdOut=/dodrio/scratch/projects/2025_600/SHARED/jobs/2026.05/pr_1461/event_125b69e0-488f-11f1-8eb7-60fa5e34a41f/run_000/x86_64/amd/zen2/nvidia/cc80/eessi.io-2025.06-software/slurm-13591760.out TresPerNode=gres/gpu:1 MailUser=vsc48506@vscentrum.be MailType=BEGIN,END,FAIL,TIME_LIMIT
```