### PR TITLE
[gitlab] Add PRComment classes and GitLab support for `bot: help` command

### DIFF
--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -38,7 +38,7 @@ from tools.args import event_handler_parse
 from tools.commands import EESSIBotCommand, EESSIBotCommandError, \
     contains_any_bot_command, get_bot_command
 from tools.event_info import create_event_info_instance
-from tools.git import connect_to_git_hosting_platform, get_git_hosting_platform
+from tools.git import connect_to_git_hosting_platform, get_app_name, get_git_hosting_platform
 from tools.permissions import check_command_permission
 from tools.pr_comments import ChatLevels, create_comment
 
@@ -209,7 +209,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         #      log level is set to debug
         self.log(f"Comment in {issue_url} (owned by @{owner}) {action} by @{sender}")
 
-        app_name = self.cfg[config.SECTION_GITHUB][config.GITHUB_SETTING_APP_NAME]
+        app_name = get_app_name(self.cfg)
         command_response_fmt = self.cfg[config.SECTION_BOT_CONTROL][config.BOT_CONTROL_SETTING_COMMAND_RESPONSE_FMT]
 
         # currently, only commands in new comments are supported

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -36,7 +36,7 @@ from tasks.clean_up import move_to_trash_bin
 from tools import config
 from tools.args import event_handler_parse
 from tools.commands import EESSIBotCommand, EESSIBotCommandError, \
-    contains_any_bot_command, get_bot_command
+    contains_any_bot_command, get_bot_command, get_supported_commands, ALL_COMMANDS
 from tools.event_info import create_event_info_instance
 from tools.git import connect_to_git_hosting_platform, get_app_name, get_git_hosting_platform
 from tools.permissions import check_command_permission
@@ -496,7 +496,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         specific bot_command given.
 
         Args:
-            event_info (dict): event received by event_handler
+            event_info (EventInfo): event received by event_handler
             bot_command (EESSIBotCommand): command to be handled
             log_file (string): path to log messages to
 
@@ -511,9 +511,13 @@ class EESSIBotSoftwareLayer(PyGHee):
         cmd = bot_command.command
         handler_name = f"handle_bot_command_{cmd}"
         if hasattr(self, handler_name):
-            handler = getattr(self, handler_name)
-            self.log(f"Handling bot command {cmd}")
-            return handler(event_info, bot_command)
+            if cmd in get_supported_commands(self.cfg):
+                handler = getattr(self, handler_name)
+                self.log(f"Handling bot command {cmd}")
+                return handler(event_info, bot_command)
+            else:
+                self.log(f"Command '{cmd}' is not supported on the configured Git hosting platform.")
+                raise EESSIBotCommandError(f"Unsupported command `{cmd}`; use `bot: help` for usage information")
         else:
             self.log(f"No handler for command '{cmd}'")
             raise EESSIBotCommandError(f"unknown command `{cmd}`; use `bot: help` for usage information")

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -367,6 +367,9 @@ class EESSIBotSoftwareLayer(PyGHee):
 
             self.log(f"issue_comment event (url {issue_url}) handled!")
 
+    # PyGHee gets the event type by subscripting event_info, i.e., it gets 'note' for GL comment events
+    handle_note_event = handle_issue_comment_event
+
     def handle_installation_event(self, event_info, log_file=None):
         """
         Handle events of type installation. Main action is to log the event.

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -188,7 +188,7 @@ class EESSIBotSoftwareLayer(PyGHee):
         comments for any bot command and execute it if one is found.
 
         Args:
-            event_info (dict): event received by event_handler
+            event_info (EventInfo): event received by event_handler
             log_file (string): path to log messages to
 
         Returns:
@@ -197,13 +197,12 @@ class EESSIBotSoftwareLayer(PyGHee):
         Raises:
             Exception: raises any exception that is not of type EESSIBotCommandError
         """
-        request_body = event_info['raw_request_body']
-        issue_url = request_body['issue']['url']
-        action = request_body['action']
-        sender = request_body['sender']['login']
-        owner = request_body['comment']['user']['login']
-        repo_name = request_body['repository']['full_name']
-        pr_number = request_body['issue']['number']
+        issue_url = event_info.issue_url
+        action = event_info.action
+        sender = event_info.event_triggered_by
+        owner = event_info.comment_created_by
+        repo_name = event_info.repo_name
+        pr_number = event_info.issue_number
 
         # TODO add request body text (['comment']['body']) to log message when
         #      log level is set to debug
@@ -217,7 +216,7 @@ class EESSIBotSoftwareLayer(PyGHee):
 
         # only scan for commands in newly created comments
         if action == 'created':
-            comment_received = request_body['comment']['body']
+            comment_received = event_info.comment_body
             self.log(f"comment action '{action}' is handled")
         else:
             # NOTE we do not respond to an updated PR comment with yet another

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -571,7 +571,7 @@ class EESSIBotSoftwareLayer(PyGHee):
             else:
                 for job_id, issue_comment in submitted_jobs.items():
                     build_msg += f"\n  - submitted job `{job_id}`"
-                    if issue_comment:
+                    if issue_comment and issue_comment.html_url:
                         build_msg += f", for details & status see {issue_comment.html_url}"
         else:
             request_body = event_info['raw_request_body']

--- a/eessi_bot_event_handler.py
+++ b/eessi_bot_event_handler.py
@@ -528,17 +528,25 @@ class EESSIBotSoftwareLayer(PyGHee):
         commands.
 
         Args:
-            event_info (dict): event received by event_handler
+            event_info (EventInfo): event received by event_handler
             bot_command (EESSIBotCommand): command to be handled
 
         Returns:
             (string): basic information about sending commands to the bot
         """
+        # Create comma-separated lists of supported and unsupported commands
+        supported_commands = get_supported_commands(self.cfg)
+        unsupported_commands = [cmd for cmd in ALL_COMMANDS if cmd not in supported_commands]
+        supported_commands_str = ", ".join([f"`{cmd}`" for cmd in supported_commands])
+        unsupported_commands_str = ", ".join([f"`{cmd}`" for cmd in unsupported_commands])
+
         help_msg = "\n  **How to send commands to bot instances**"
         help_msg += "\n  - Commands must be sent with a **new** comment (edits of existing comments are ignored)."
         help_msg += "\n  - A comment may contain multiple commands, one per line."
         help_msg += "\n  - Every command begins at the start of a line and has the syntax `bot: COMMAND [ARGUMENTS]*`"
-        help_msg += "\n  - Currently supported COMMANDs are: `help`, `build`, `show_config`, `status`, `cancel`"
+        help_msg += "\n  - Currently supported COMMANDs are: " + supported_commands_str
+        if unsupported_commands_str:
+            help_msg += "\n  - The following COMMANDs are not yet supported: " + unsupported_commands_str
         help_msg += "\n"
         help_msg += "\n  For more information, see https://www.eessi.io/docs/bot"
         return help_msg

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ python-gitlab==6.5.0;python_version=="3.9" # Last version with Python 3.9 suppor
 python-gitlab==8.3.0;python_version>="3.10" # Most recent version on 2026-05-04
 Waitress>=3.0.1 # required to fix vulnerabilities detected by scorecards
 cryptography>=44.0.1 # required to fix vulnerabilities detected by scorecards
-PyGHee @ git+https://github.com/boegel/PyGHee.git@c5e10632a45db5ca94f5cbf87ac7a90a2064e8fd # Pin commit with GL support
+PyGHee @ git+https://github.com/boegel/PyGHee.git@514bdf6b7db1ed2a965ccdabaf45f9e9b1d825b7 # Pin commit with GL support
 retry

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -1078,7 +1078,7 @@ def submit_build_jobs(pr, event_info, action_filter, build_params):
         pr_comment = create_pr_comment(job, job_id, app_name, pr, symlink, build_params)
         job_id_to_comment_map[job_id] = pr_comment
 
-        pr_comment = pr_comments.PRComment(pr.base.repo.full_name, pr.number, pr_comment.id)
+        pr_comment = pr_comments.PRCommentInfo(pr.base.repo.full_name, pr.number, pr_comment.id)
 
         # create _bot_job<jobid>.metadata file in the job's working directory
         job_metadata.create_metadata_file(job, job_id, pr_comment)

--- a/tests/test_app.cfg
+++ b/tests/test_app.cfg
@@ -11,6 +11,9 @@
 
 # sample config file for tests (some functions run config.read_config()
 # which reads app.cfg by default)
+[git]
+hosting_platform = github
+
 [buildenv]
 job_handover_protocol = hold_release
 

--- a/tests/test_task_build.py
+++ b/tests/test_task_build.py
@@ -30,7 +30,7 @@ from tasks.build import Job, create_pr_comment
 from tools import run_cmd, run_subprocess
 from tools.build_params import EESSIBotBuildParams
 from tools.job_metadata import create_metadata_file, read_metadata_file
-from tools.pr_comments import PRComment, get_submitted_job_comment
+from tools.pr_comments import PRCommentInfo, get_submitted_job_comment
 
 # Local tests imports (reusing code from other tests)
 from tests.test_tools_pr_comments import MockIssueComment
@@ -462,7 +462,7 @@ def test_create_read_metadata_file(mocked_github, tmp_path):
     job_id = "123"
 
     repo_name = "test_repo"
-    pr_comment = PRComment(repo_name, pr_number, 77)
+    pr_comment = PRCommentInfo(repo_name, pr_number, 77)
     create_metadata_file(job, job_id, pr_comment)
 
     expected_file = f"_bot_job{job_id}.metadata"

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -19,6 +19,29 @@ from pyghee.utils import log
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
 from tools.filter import EESSIBotActionFilter, EESSIBotActionFilterError
 from tools.build_params import EESSIBotBuildParams
+from tools.git import get_git_hosting_platform, GITHUB, GITLAB
+
+
+ALL_COMMANDS = ["help", "build", "show_config", "status", "cancel"]
+SUPPORTED_COMMANDS_PER_GIT_HOST = {
+    GITHUB: ["help", "build", "show_config", "status", "cancel"],
+    GITLAB: [],
+}
+
+
+def get_supported_commands(cfg=None):
+    """
+    Returns the supported commands for the configured Git hosting platform.
+
+    Args:
+        cfg (ConfigParser): Instance of ConfigParser containing the configuration.
+            May be passed by caller to avoid re-reading the configuration file.
+
+    Returns:
+        supported_commands (list of strings): The supported commands
+    """
+    git_host = get_git_hosting_platform(cfg)
+    return SUPPORTED_COMMANDS_PER_GIT_HOST[git_host]
 
 
 def contains_any_bot_command(body):

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -25,7 +25,7 @@ from tools.git import get_git_hosting_platform, GITHUB, GITLAB
 ALL_COMMANDS = ["help", "build", "show_config", "status", "cancel"]
 SUPPORTED_COMMANDS_PER_GIT_HOST = {
     GITHUB: ["help", "build", "show_config", "status", "cancel"],
-    GITLAB: [],
+    GITLAB: ["help"],
 }
 
 

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -11,6 +11,7 @@
 
 # Standard library imports
 from functools import cached_property
+from typing import Union
 
 # Third party imports (anything installed into the local Python environment)
 # (none)
@@ -318,6 +319,10 @@ class GitLabEventInfo(BaseEventInfo):
         return self._request_body["project"]["path_with_namespace"]
 
 
+# Type for subclasses of BaseEventInfo
+EventInfo = Union[GitHubEventInfo, GitLabEventInfo]
+
+
 def create_event_info_instance(event_info):
     """
     Creates an EventInfo instance for the configured Git hosting platform.
@@ -326,7 +331,7 @@ def create_event_info_instance(event_info):
         event_info (dict): The event info dictionary created by PyGHee
 
     Returns:
-        Instance of BaseEventInfo subclass
+        EventInfo instance or None
     """
     git_host = get_git_hosting_platform()
     if git_host == GITHUB:

--- a/tools/event_info.py
+++ b/tools/event_info.py
@@ -252,10 +252,10 @@ class GitLabEventInfo(BaseEventInfo):
     # We therefore need to check what type of comment it is to get the issue numbers and URLs.
     @cached_property
     def issue_number(self):
-        notable_type = self._object_attributes["notable_type"]
-        if notable_type == "MergeRequest":
+        noteable_type = self._object_attributes["noteable_type"]
+        if noteable_type == "MergeRequest":
             issue_iid = self._request_body["merge_request"]["iid"]
-        elif notable_type == "Issue":
+        elif noteable_type == "Issue":
             issue_iid = self._request_body["issue"]["iid"]
         else:
             # Comments may also come from commits etc. - default to -1
@@ -264,10 +264,10 @@ class GitLabEventInfo(BaseEventInfo):
 
     @cached_property
     def issue_url(self):
-        notable_type = self._object_attributes["notable_type"]
-        if notable_type == "MergeRequest":
+        noteable_type = self._object_attributes["noteable_type"]
+        if noteable_type == "MergeRequest":
             issue_url = self._request_body["merge_request"]["url"]
-        elif notable_type == "Issue":
+        elif noteable_type == "Issue":
             issue_url = self._request_body["issue"]["url"]
         else:
             # Comments may also come from commits etc. - default to empty string

--- a/tools/git.py
+++ b/tools/git.py
@@ -71,3 +71,25 @@ def connect_to_git_hosting_platform():
         gitlab.connect()
     else:
         logging.error(f"Git host not supported: '{git_host}'")
+
+
+# TODO: We might consider merging these settings later, for example as an 'app_name' setting in the 'git' section
+def get_app_name(cfg=None):
+    """
+    Get the configured app/bot name.
+
+    Args:
+        cfg (ConfigParser): Instance of ConfigParser containing the configuration.
+            May be passed by caller to avoid re-reading the configuration file.
+
+    Returns:
+        (str): The configured app/bot name or None
+    """
+    if not cfg:
+        cfg = config.read_config()
+    git_host = get_git_hosting_platform(cfg)
+    if git_host == GITHUB:
+        return cfg.get(config.SECTION_GITHUB, config.GITHUB_SETTING_APP_NAME)
+    elif git_host == GITLAB:
+        return cfg.get(config.SECTION_GITLAB, config.GITLAB_SETTING_BOT_NAME)
+    return None

--- a/tools/job_metadata.py
+++ b/tools/job_metadata.py
@@ -90,7 +90,7 @@ def create_metadata_file(job, job_id, pr_comment):
     Args:
         job (named tuple): key data about job that has been submitted
         job_id (string): id of submitted job
-        pr_comment (PRComment): contains repo_name, pr_number and pr_comment_id
+        pr_comment (PRCommentInfo): contains repo_name, pr_number and pr_comment_id
 
     Returns:
         None (implicitly)

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -295,16 +295,14 @@ class GitHubPRComment(BasePRComment):
         return None
 
     def get(self):
-        if not self.id:
-            raise Exception("'id' must be set to get a comment.")
+        self._require_id()
         self._comment_obj = retry_call(self._pr_obj.get_issue_comment, fargs=[self.id],
                                        exceptions=Exception, tries=5, delay=1, backoff=2, max_delay=30)
         if self._comment_obj:
             self.body = self._comment_obj.body
 
     def create(self):
-        if not self.body:
-            raise Exception("'body' must be set to create a comment.")
+        self._require_body()
         if self.id:
             # Safeguard: id should not be set when body is initialized, but guard
             # against accidental duplicate comments if id was set after initialization.
@@ -315,8 +313,7 @@ class GitHubPRComment(BasePRComment):
             self.id = self._comment_obj.id
 
     def edit(self, new_body):
-        if not self.id:
-            raise Exception("'id' must be set to edit a comment.")
+        self._require_id()
         # Ensure comment object is present
         if not self._comment_obj:
             self.get()
@@ -325,8 +322,7 @@ class GitHubPRComment(BasePRComment):
                    tries=5, delay=1, backoff=2, max_delay=30)
 
     def append(self, text_to_append):
-        if not self.id:
-            raise Exception("'id' must be set to append to a comment.")
+        self._require_id()
         # Ensure comment object is present and up to date
         self.get()
         self.edit(self.body + text_to_append)
@@ -350,14 +346,12 @@ class GitLabPRComment(BasePRComment):
         return None
 
     def get(self):
-        if not self.id:
-            raise Exception("'id' must be set to get a comment.")
+        self._require_id()
         self._comment_obj = self._pr_obj.notes.get(self.id)
         self.body = self._comment_obj.body
 
     def create(self):
-        if not self.body:
-            raise Exception("'body' must be set to create a comment.")
+        self._require_body()
         if self.id:
             # Safeguard: id should not be set when body is initialized, but guard
             # against accidental duplicate comments if id was set after initialization.
@@ -367,8 +361,7 @@ class GitLabPRComment(BasePRComment):
             self.id = self._comment_obj.id
 
     def edit(self, new_body):
-        if not self.id:
-            raise Exception("'id' must be set to edit a comment.")
+        self._require_id()
         # Ensure comment object is present
         if not self._comment_obj:
             self.get()
@@ -377,8 +370,7 @@ class GitLabPRComment(BasePRComment):
         self._comment_obj.save()
 
     def append(self, text_to_append):
-        if not self.id:
-            raise Exception("'id' must be set to append to a comment.")
+        self._require_id()
         # Ensure comment object and body are present and up to date
         self.get()
         self.edit(self.body + text_to_append)

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -276,8 +276,8 @@ class GitHubPRComment(BasePRComment):
         if not self.body:
             raise Exception("'body' must be set to create a comment.")
         if self.id:
-        # Safeguard: id should not be set when body is initialized, but guard
-        # against accidental duplicate comments if id was set after initialization.
+            # Safeguard: id should not be set when body is initialized, but guard
+            # against accidental duplicate comments if id was set after initialization.
             return
         self._comment_obj = retry_call(self._pr_obj.create_issue_comment, fargs=[self.body],
                                        exceptions=Exception, tries=3, delay=1, backoff=2, max_delay=10)
@@ -329,8 +329,8 @@ class GitLabPRComment(BasePRComment):
         if not self.body:
             raise Exception("'body' must be set to create a comment.")
         if self.id:
-        # Safeguard: id should not be set when body is initialized, but guard
-        # against accidental duplicate comments if id was set after initialization.
+            # Safeguard: id should not be set when body is initialized, but guard
+            # against accidental duplicate comments if id was set after initialization.
             return
         self._comment_obj = self._pr_obj.notes.create({"body": self.body})
         if self._comment_obj:

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -46,7 +46,7 @@ class ChatLevels(Enum):
 
 def create_comment(repo_name, pr_number, comment, req_chatlevel):
     """
-    Create a comment to a pull request on GitHub
+    Create a comment to a pull request
 
     Args:
         repo_name (string): name of the repository
@@ -55,8 +55,7 @@ def create_comment(repo_name, pr_number, comment, req_chatlevel):
         req_chatlevel (member of ChatLevels Enum): minimum required chattiness level for creating the PR comment
 
     Returns:
-        github.IssueComment.IssueComment instance or None (note, github refers to
-            PyGithub, not the github from the internal connections module)
+        PRComment instance or None
     """
     fn = sys._getframe().f_code.co_name
 
@@ -65,12 +64,12 @@ def create_comment(repo_name, pr_number, comment, req_chatlevel):
         config.BOT_CONTROL_SETTING_CHATLEVEL, ChatLevels.BASIC.name).upper()
 
     if ChatLevels[chatlevel].value >= req_chatlevel.value:
-        gh = github.get_instance()
-        repo = gh.get_repo(repo_name)
-        pull_request = repo.get_pull(pr_number)
-        issue_comment = retry_call(pull_request.create_issue_comment, fargs=[comment],
-                                   exceptions=Exception, tries=3, delay=1, backoff=2, max_delay=10)
-        return issue_comment
+        pr_comment = create_pr_comment_instance(repo_name, pr_number, body=comment)
+        pr_comment.create()
+        # If 'id' is not set, something went wrong
+        if not pr_comment.id:
+            return None
+        return pr_comment
 
     else:
         log(f"{fn}(): not creating PR comment: "

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -234,7 +234,7 @@ class BasePRComment(ABC):
     def body(self, value):
         # Ensure 'body' is not a blank string
         if value is not None and not value.strip():
-            raise ValueError("'body' must not be empty") 
+            raise ValueError("'body' must not be empty")
         self._body = value
 
     @property
@@ -245,7 +245,7 @@ class BasePRComment(ABC):
     def id(self, value):
         # Ensure 'id' is not a blank string
         if value is not None and not str(value).strip():
-            raise ValueError("'id' must not be empty") 
+            raise ValueError("'id' must not be empty")
         self._id = value
 
     def _require_body(self):

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -30,7 +30,7 @@ from connections import github
 from tools import config
 
 
-PRComment = namedtuple('PRComment', ('repo_name', 'pr_number', 'pr_comment_id'))
+PRCommentInfo = namedtuple('PRCommentInfo', ('repo_name', 'pr_number', 'pr_comment_id'))
 
 
 class ChatLevels(Enum):

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -276,7 +276,8 @@ class GitHubPRComment(BasePRComment):
         if not self.body:
             raise Exception("'body' must be set to create a comment.")
         if self.id:
-            # Return early if 'id' is set to avoid creating duplicate comments
+        # Safeguard: id should not be set when body is initialized, but guard
+        # against accidental duplicate comments if id was set after initialization.
             return
         self._comment_obj = retry_call(self._pr_obj.create_issue_comment, fargs=[self.body],
                                        exceptions=Exception, tries=3, delay=1, backoff=2, max_delay=10)
@@ -328,7 +329,8 @@ class GitLabPRComment(BasePRComment):
         if not self.body:
             raise Exception("'body' must be set to create a comment.")
         if self.id:
-            # Return early if 'id' is set to avoid creating duplicate comments
+        # Safeguard: id should not be set when body is initialized, but guard
+        # against accidental duplicate comments if id was set after initialization.
             return
         self._comment_obj = self._pr_obj.notes.create({"body": self.body})
         if self._comment_obj:

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -16,6 +16,7 @@
 #
 
 # Standard library imports
+from abc import abstractmethod, ABC
 from collections import namedtuple
 from enum import Enum
 import re
@@ -196,22 +197,27 @@ def update_pr_comment(event_info, update):
     issue_comment.edit(comment_new + update)
 
 
-class BasePRComment():
+class BasePRComment(ABC):
     """
     Base class to use for handling PR comments, which works differently for GitHub vs. GitLab.
+
+    Args:
+        repo_name (str): Full name of the repository (e.g. 'user/repo')
+        pr_number (int): Pull request number
+        body (str, optional): Comment body. Provide when creating a new comment.
+        id (int, optional): ID of an existing comment. Provide when referencing an existing comment.
+
+    Exactly one of body or id must be provided.
     """
     def __init__(self, repo_name, pr_number, body=None, id=None):
-        if self.__class__ is BasePRComment:
-            err_msg = "Do not use this base class directly. "
-            err_msg += "Please use one of its subclasses instead."
-            raise NotImplementedError(err_msg)
-
-        # 'body' should be provided when creating a new comment
-        # 'id' should be provided when dealing with an existing comment
-        if (body and id) or not (body or id):
-            err_msg = "Exactly one of 'body' and 'id' must be "
+        # Exactly one of body (new comment) or id (existing comment) must be provided
+        if (body is None) == (id is None):
+            err_msg = "Exactly one of 'body' or 'id' must be "
             err_msg += "set when initializing a comment class."
-            raise Exception(err_msg)
+            raise ValueError(err_msg)
+
+        if id is not None and not str(id).strip():
+            raise ValueError("'id' must not be empty.")
 
         self.body = body
         self.id = id
@@ -221,20 +227,25 @@ class BasePRComment():
         self._comment_obj = None
 
     @property
+    @abstractmethod
     def html_url(self):
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get(self):
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def create(self):
-        raise NotImplementedError()
+        pass
 
-    def edit(self):
-        raise NotImplementedError()
+    @abstractmethod
+    def edit(self, new_body):
+        pass
 
-    def append(self):
-        raise NotImplementedError()
+    @abstractmethod
+    def append(self, text_to_append):
+        pass
 
 
 class GitHubPRComment(BasePRComment):

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -248,6 +248,14 @@ class BasePRComment(ABC):
             raise ValueError("'id' must not be empty") 
         self._id = value
 
+    def _require_body(self):
+        if self.body is None:
+            raise ValueError("'body' must be set.")
+
+    def _require_id(self):
+        if self.id is None:
+            raise ValueError("'id' must be set.")
+
     @property
     @abstractmethod
     def html_url(self):

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -227,6 +227,28 @@ class BasePRComment(ABC):
         self._comment_obj = None
 
     @property
+    def body(self):
+        return self._body
+
+    @body.setter
+    def body(self, value):
+        # Ensure 'body' is not a blank string
+        if value is not None and not value.strip():
+            raise ValueError("'body' must not be empty") 
+        self._body = value
+
+    @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        # Ensure 'id' is not a blank string
+        if value is not None and not str(value).strip():
+            raise ValueError("'id' must not be empty") 
+        self._id = value
+
+    @property
     @abstractmethod
     def html_url(self):
         pass

--- a/tools/pr_comments.py
+++ b/tools/pr_comments.py
@@ -10,6 +10,7 @@
 # author: Jonas Qvigstad (@jonas-lq)
 # author: Thomas Roeblitz (@trz42)
 # author: Sam Moors (@smoors)
+# author: Sondre Bergsvaag Risanger (@sondrebr)
 #
 # license: GPLv2
 #
@@ -19,6 +20,7 @@ from collections import namedtuple
 from enum import Enum
 import re
 import sys
+from typing import Union
 
 # Third party imports (anything installed into the local Python environment)
 from pyghee.utils import log
@@ -26,8 +28,9 @@ from retry import retry
 from retry.api import retry_call
 
 # Local application imports (anything from EESSI/eessi-bot-software-layer)
-from connections import github
+from connections import github, gitlab
 from tools import config
+from tools.git import get_git_hosting_platform, GITHUB, GITLAB
 
 
 PRCommentInfo = namedtuple('PRCommentInfo', ('repo_name', 'pr_number', 'pr_comment_id'))
@@ -192,3 +195,175 @@ def update_pr_comment(event_info, update):
     pull_request = repo.get_pull(pr_number)
     issue_comment = pull_request.get_issue_comment(issue_id)
     issue_comment.edit(comment_new + update)
+
+
+class BasePRComment():
+    """
+    Base class to use for handling PR comments, which works differently for GitHub vs. GitLab.
+    """
+    def __init__(self, repo_name, pr_number, body=None, id=None):
+        if self.__class__ is BasePRComment:
+            err_msg = "Do not use this base class directly. "
+            err_msg += "Please use one of its subclasses instead."
+            raise NotImplementedError(err_msg)
+
+        # 'body' should be provided when creating a new comment
+        # 'id' should be provided when dealing with an existing comment
+        if (body and id) or not (body or id):
+            err_msg = "Exactly one of 'body' and 'id' must be "
+            err_msg += "set when initializing a comment class."
+            raise Exception(err_msg)
+
+        self.body = body
+        self.id = id
+        self.repo_name = repo_name
+        self.pr_number = pr_number
+        self._pr_obj = None
+        self._comment_obj = None
+
+    @property
+    def html_url(self):
+        raise NotImplementedError()
+
+    def get(self):
+        raise NotImplementedError()
+
+    def create(self):
+        raise NotImplementedError()
+
+    def edit(self):
+        raise NotImplementedError()
+
+    def append(self):
+        raise NotImplementedError()
+
+
+class GitHubPRComment(BasePRComment):
+    """
+    PRComment class for use with GitHub.
+    """
+    def __init__(self, repo_name, pr_number, body=None, id=None):
+        super().__init__(repo_name, pr_number, body, id)
+        gh = github.get_instance()
+        repo = gh.get_repo(self.repo_name)
+        self._pr_obj = repo.get_pull(self.pr_number)
+
+    @property
+    def html_url(self):
+        if self._comment_obj:
+            return self._comment_obj.html_url
+        return None
+
+    def get(self):
+        if not self.id:
+            raise Exception("'id' must be set to get a comment.")
+        self._comment_obj = retry_call(self._pr_obj.get_issue_comment, fargs=[self.id],
+                                       exceptions=Exception, tries=5, delay=1, backoff=2, max_delay=30)
+        if self._comment_obj:
+            self.body = self._comment_obj.body
+
+    def create(self):
+        if not self.body:
+            raise Exception("'body' must be set to create a comment.")
+        if self.id:
+            # Return early if 'id' is set to avoid creating duplicate comments
+            return
+        self._comment_obj = retry_call(self._pr_obj.create_issue_comment, fargs=[self.body],
+                                       exceptions=Exception, tries=3, delay=1, backoff=2, max_delay=10)
+        if self._comment_obj:
+            self.id = self._comment_obj.id
+
+    def edit(self, new_body):
+        if not self.id:
+            raise Exception("'id' must be set to edit a comment.")
+        # Ensure comment object is present
+        if not self._comment_obj:
+            self.get()
+        self.body = new_body
+        retry_call(self._comment_obj.edit, fargs=[self.body], exceptions=Exception,
+                   tries=5, delay=1, backoff=2, max_delay=30)
+
+    def append(self, text_to_append):
+        if not self.id:
+            raise Exception("'id' must be set to append to a comment.")
+        # Ensure comment object is present and up to date
+        self.get()
+        self.edit(self.body + text_to_append)
+
+
+class GitLabPRComment(BasePRComment):
+    """
+    PRComment class for use with GitLab.
+    """
+    def __init__(self, repo_name, pr_number, body=None, id=None):
+        super().__init__(repo_name, pr_number, body, id)
+        gl = gitlab.get_instance()
+        proj = gl.projects.get(self.repo_name)
+        self._pr_obj = proj.mergerequests.get(self.pr_number)
+
+    @property
+    def html_url(self):
+        if self._comment_obj:
+            # GitLab comment object does not include a comment URL
+            return f"{self._pr_obj.web_url}#note_{self._comment_obj.id}"
+        return None
+
+    def get(self):
+        if not self.id:
+            raise Exception("'id' must be set to get a comment.")
+        self._comment_obj = self._pr_obj.notes.get(self.id)
+        self.body = self._comment_obj.body
+
+    def create(self):
+        if not self.body:
+            raise Exception("'body' must be set to create a comment.")
+        if self.id:
+            # Return early if 'id' is set to avoid creating duplicate comments
+            return
+        self._comment_obj = self._pr_obj.notes.create({"body": self.body})
+        if self._comment_obj:
+            self.id = self._comment_obj.id
+
+    def edit(self, new_body):
+        if not self.id:
+            raise Exception("'id' must be set to edit a comment.")
+        # Ensure comment object is present
+        if not self._comment_obj:
+            self.get()
+        self.body = new_body
+        self._comment_obj.body = self.body
+        self._comment_obj.save()
+
+    def append(self, text_to_append):
+        if not self.id:
+            raise Exception("'id' must be set to append to a comment.")
+        # Ensure comment object and body are present and up to date
+        self.get()
+        self.edit(self.body + text_to_append)
+
+
+# Type for subclasses of BasePRComment
+PRComment = Union[GitHubPRComment, GitLabPRComment]
+
+
+def create_pr_comment_instance(repo_name, pr_number, body=None, id=None):
+    """
+    Creates a PRComment instance for the configured Git hosting platform.
+
+    Args:
+        repo_name (string): The name of the repository
+        pr_number (int): The number of the pull request in the repository
+        body (string): The comment body. Required when creating a new comment.
+            Cannot be set at the same time as 'id'.
+        id (int): The ID of the comment. Required when getting and/or updating
+            an existing comment. Cannot be set at the same time as 'body'.
+
+    Returns:
+        PRComment instance or None
+    """
+    git_host = get_git_hosting_platform()
+    if git_host == GITHUB:
+        return GitHubPRComment(repo_name=repo_name, pr_number=pr_number, body=body, id=id)
+    elif git_host == GITLAB:
+        return GitLabPRComment(repo_name=repo_name, pr_number=pr_number, body=body, id=id)
+    return None


### PR DESCRIPTION
Another step in implementing GitLab support for the bot, most notably making it support the `bot: help` command. Changes include:
- In `tools/pr_comments.py`:
  - Existing `PRComment` class renamed to `PRCommentInfo`
  - Added `BasePRComment` class, "interface" to implement for each Git hosting platform to support creating/getting/editing PR comments
  - Added `GitHubPRComment` class, GitHub implementation of `BasePRComment`
  - Added `GitLabPRComment` class, GitLab implementation of `BasePRComment`
  - Added `create_pr_comment_instance()` function creating an instance of the correct `PRComment` class
  - Changed the `create_comment()` function to use the `PRComment` classes
- In `tools/commands.py`:
  - Added `ALL_COMMANDS` constant (list containing all existing bot commands)
  - Added `SUPPORTED_COMMANDS_PER_GIT_HOST` constant (dictionary listing supported/implemented commands per Git hosting platform)
  - Added `get_supported_commands()` function retrieving the supported commands for the configured Git hosting platform
- In `eessi_bot_event_handler.py`:
  - Change `handle_issue_comment_event()` method to use the EventInfo properties and `get_app_name()`
  - Add `handle_note_event = handle_issue_comment_event` to make the bot process GitLab comments
  - Change `handle_bot_command()` method to check if command is supported on the configured Git hosting platform
  - Change `bot: help` response message to include a list of unsupported commands (if any)
- Added `get_app_name()` to `tools/git.py` to get the app/bot name (separate settings for GitHub/GitLab)
- Updated PyGHee dependecy
- Typo fix in EventInfo (I had used `notable_type`  instead of `noteable_type` 🤦)
- EventInfo and PRComment types (referring to subclasses of BaseEventInfo and BasePRComment, respectively)

# Usage
To use the bot in its current state on GitLab, follow the Usage section in the description of #370, except:
- When updating PyGHee, check that commit `514bdf6...` is installed.
- The GitLab access token must have the `api` scope and the *Reporter* role (not Planner!) for the bot to be able to post comments.
- Setting up a custom Smee server is no longer required *if* you use GitLab.com or GitLab CE/EE 19.0 or above, as they support signing tokens on webhooks. In that case, GitLab will generate a signing token for you, which must be stored as the `GITLAB_WEBHOOK_SECRET_TOKEN` environment variable. Make sure to include the `whsec_` prefix.
  - Side note if using GitLab.com: AFAIK it is not possible to create project access tokens on the free plan. One can however create a service account in the group/project and generate an access token for the service account.
- If using a GitLab instance without support for signing tokens, you still need to use a custom Smee server. Additionally, you need to use a webhook secret similar to the signing tokens GitLab generates, consisting of 32 bytes encoded in base64, prefixed with `whsec_`. These can be generated e.g. by running `python -c "import base64, secrets; print('whsec_' + base64.b64encode(secrets.token_bytes(32)).decode())"`.